### PR TITLE
Add sendSlackChannelMessage to send message directly to a channel

### DIFF
--- a/commons/src/main/java/com/pinterest/slate/process/taskdefinitions/SlackTask.java
+++ b/commons/src/main/java/com/pinterest/slate/process/taskdefinitions/SlackTask.java
@@ -41,6 +41,7 @@ public class SlackTask extends TaskDefinition {
   private static final String EMAIL_DOMAIN = System.getenv("EMAIL_DOMAIN") == null ? "admin@local"
       : System.getenv("EMAIL_DOMAIN");
   public static final String USERNAME = "username";
+  public static final String CHANNEL = "channel";
   public static final String LINK = "link";
   public static final String MESSAGE = "message";
   public static final String TITLE = "title";


### PR DESCRIPTION
Update SlackTask to make it be able to send messages to a slack channel directly. SlackTask can be created with both/either username and/or channel id. The message can also be sent twice. 

Current logic in `sendSlackMessage` is to take username as input and use usersLookupByEmail to get the channel id, then it sends the message. It cannot send message to channel.  

#### Q: Why not refactor `sendSlackMessage`? 
sendSlackMessage is called at different places. i need to split sendSlackMessage method into two methods (username lookup / message call) to make it keep the original functionalities. So i just create a new method instead. 

#### Q: Where's the `link` value? 
I have a better way to render the link so i remove it from the method.
