### PR TITLE
Add client-side #graph= handoff to hydrate the Builder

### DIFF
--- a/core/src/main/resources/webapp/src/components/builder/BuilderView.tsx
+++ b/core/src/main/resources/webapp/src/components/builder/BuilderView.tsx
@@ -13,7 +13,7 @@ import {
     setOpenResourceEditor,
 } from '../../store/slice/builder';
 import { TNode } from '../../const/types';
-import { decodeGraphFragment, nodesFromResourceMap } from '../../const/graphHandoff';
+import { decodeGraphFragment, hasGraphFragment, nodesFromResourceMap } from '../../const/graphHandoff';
 import TopologyBuilder from '../../topology/TopologyBuilder';
 import { useSnackBar } from '../../context/SnackbarContext';
 import { useLoadingSpinner } from '../../context/LoadingSpinnerContext';
@@ -109,24 +109,42 @@ const BuilderView: React.FC<IBuilderViewProps> = () => {
     };
 
     const hydrateFromFragment = async () => {
-        const map = await decodeGraphFragment(window.location.hash);
-        if (!map) {
+        // Nothing to do (and nothing to scrub) if there's no #graph= payload.
+        if (!hasGraphFragment(window.location.hash)) {
             return;
         }
-        const nodes = nodesFromResourceMap(map);
-        dispatch(addWorkspaceTab({ makeActive: true }));
-        dispatch(addNodesToWorkspace({ nodes }));
-        dispatch(setNodeToEdit(null));
-        dispatch(setOpenResourceEditor(false));
+        const map = await decodeGraphFragment(window.location.hash);
+        if (map) {
+            const nodes = nodesFromResourceMap(map);
+            dispatch(addWorkspaceTab({ makeActive: true }));
+            dispatch(addNodesToWorkspace({ nodes }));
+            dispatch(setNodeToEdit(null));
+            dispatch(setOpenResourceEditor(false));
+            showSnackbar({
+                type: 'success',
+                message: 'Loaded proposed graph — review, run Plan, then Execute.',
+            });
+        } else {
+            // A #graph= payload was present but invalid (malformed, or not a
+            // create-only graph). No-op the hydration, but tell the user why
+            // nothing loaded, and still scrub it below.
+            console.warn('Ignoring invalid #graph= handoff payload.');
+            showSnackbar({
+                type: 'error',
+                message: 'That graph link was invalid or unsupported — nothing was loaded.',
+            });
+        }
 
-        // Remove the payload from the address bar / current history entry so it
-        // doesn't re-hydrate on re-render, linger in the URL, or get re-shared.
-        window.history.replaceState(null, '', window.location.pathname + window.location.search);
-
-        showSnackbar({
-            type: 'success',
-            message: 'Loaded proposed graph — review, run Plan, then Execute.',
-        });
+        // Remove the payload from the address bar / current history entry —
+        // whether it hydrated or was rejected — so it doesn't re-hydrate on
+        // re-render, linger in the URL, or get re-shared. Preserve the existing
+        // history state (React Router keeps its location key/idx there) so we
+        // only drop the fragment, not the router metadata.
+        window.history.replaceState(
+            window.history.state,
+            '',
+            window.location.pathname + window.location.search
+        );
     };
 
     if (!resourceDefinitions) {

--- a/core/src/main/resources/webapp/src/components/builder/BuilderView.tsx
+++ b/core/src/main/resources/webapp/src/components/builder/BuilderView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useSearchParams, useParams } from 'react-router-dom';
 import { RootState } from '../../store/index';
@@ -13,6 +13,7 @@ import {
     setOpenResourceEditor,
 } from '../../store/slice/builder';
 import { TNode } from '../../const/types';
+import { decodeGraphFragment, nodesFromResourceMap } from '../../const/graphHandoff';
 import TopologyBuilder from '../../topology/TopologyBuilder';
 import { useSnackBar } from '../../context/SnackbarContext';
 import { useLoadingSpinner } from '../../context/LoadingSpinnerContext';
@@ -29,13 +30,26 @@ const BuilderView: React.FC<IBuilderViewProps> = () => {
     const dispatch = useDispatch();
     const { showSnackbar } = useSnackBar();
     const { showLoadingOverlay } = useLoadingSpinner();
-    const { resourceDefinitions, selectedTabId } = useSelector(selectBuilderState);
+    const { resourceDefinitions, selectedTabId, workspaceLoaded } = useSelector(selectBuilderState);
+    const hydratedFromFragmentRef = useRef(false);
     const tabData = useSelector((state: RootState) => selectWorkspaceTabData(state, selectedTabId));
     const { nodes, edges } = tabData ?? {};
 
     useEffect(() => {
         fetchResourceDefinitions();
     }, []);
+
+    // Hydrate a create-only graph handed off via the URL fragment (#graph=...).
+    // Gated on workspaceLoaded so we run *after* TopologyBuilder's onRestore has
+    // set up a consistent tabs map + selectedTabId; running during mount races
+    // that restore and the injected nodes get dropped.
+    useEffect(() => {
+        if (!workspaceLoaded || hydratedFromFragmentRef.current) {
+            return;
+        }
+        hydratedFromFragmentRef.current = true;
+        hydrateFromFragment();
+    }, [workspaceLoaded]);
 
     const fetchResourceDefinitions = () => {
         showLoadingOverlay(true);
@@ -92,6 +106,27 @@ const BuilderView: React.FC<IBuilderViewProps> = () => {
                     message: `Could not find any resource with ID: ${resourceId}`,
                 });
             });
+    };
+
+    const hydrateFromFragment = async () => {
+        const map = await decodeGraphFragment(window.location.hash);
+        if (!map) {
+            return;
+        }
+        const nodes = nodesFromResourceMap(map);
+        dispatch(addWorkspaceTab({ makeActive: true }));
+        dispatch(addNodesToWorkspace({ nodes }));
+        dispatch(setNodeToEdit(null));
+        dispatch(setOpenResourceEditor(false));
+
+        // Remove the payload from the address bar / current history entry so it
+        // doesn't re-hydrate on re-render, linger in the URL, or get re-shared.
+        window.history.replaceState(null, '', window.location.pathname + window.location.search);
+
+        showSnackbar({
+            type: 'success',
+            message: 'Loaded proposed graph — review, run Plan, then Execute.',
+        });
     };
 
     if (!resourceDefinitions) {

--- a/core/src/main/resources/webapp/src/const/graphHandoff.ts
+++ b/core/src/main/resources/webapp/src/const/graphHandoff.ts
@@ -1,4 +1,5 @@
 import { INodeData, TNode } from './types';
+import { NEW_NODE_ID_PREFIX } from './constants';
 
 /**
  * Agent -> Builder handoff.
@@ -13,6 +14,13 @@ import { INodeData, TNode } from './types';
  * included in the Referer header, so the graph stays client-side only. The
  * Builder decodes it and hydrates the workspace by reusing the same node-
  * injection path recipes use (see nodesFromResourceMap / addNodesToWorkspace).
+ *
+ * The handoff is create-only, and that is *enforced* here (see
+ * isCreateOnlyResource), not merely documented: the fragment is attacker-
+ * controllable (a crafted link) and the decoded graph flows straight into the
+ * workspace and then Plan/Execute. Every resource must be a brand-new node
+ * (temporary id, the same convention isNewNode uses) and may not request an
+ * update or deletion of an existing resource.
  */
 export type ResourceMap = Record<string, INodeData>;
 
@@ -47,8 +55,51 @@ const bytesToText = async (bytes: Uint8Array): Promise<string> => {
 };
 
 /**
+ * A handed-off resource must be a well-formed, create-only node:
+ *  - a plain object keyed in the map by its own id,
+ *  - a *temporary* id (NEW_NODE_ID_PREFIX) so the backend treats it as a create
+ *    rather than an update/delete of an existing resource,
+ *  - not a deletion (`deleted: true`),
+ *  - carrying the fields we dereference to render a node and to Plan.
+ * Anything else fails validation and causes the whole payload to be rejected,
+ * so decodeGraphFragment returns null instead of letting a malformed or
+ * destructive graph reach the workspace.
+ */
+const isCreateOnlyResource = (id: string, value: unknown): value is INodeData => {
+    if (!value || typeof value !== 'object') {
+        return false;
+    }
+    const r = value as Record<string, unknown>;
+    // create-only: temporary id that matches its map key.
+    if (typeof r.id !== 'string' || r.id !== id || !r.id.startsWith(NEW_NODE_ID_PREFIX)) {
+        return false;
+    }
+    // reject destructive/update intent — a create-only graph never deletes.
+    if (r.deleted === true) {
+        return false;
+    }
+    // shape required to render a node (type) and to Plan (desiredState).
+    if (typeof r.resourceDefinitionClass !== 'string') {
+        return false;
+    }
+    if (!r.desiredState || typeof r.desiredState !== 'object') {
+        return false;
+    }
+    return true;
+};
+
+/**
+ * Whether a `#graph=` payload is present at all. Lets callers distinguish
+ * "no handoff link" from "a handoff link that failed validation" — both of
+ * which decodeGraphFragment reports as null — so a rejected payload can still
+ * be scrubbed from the URL.
+ */
+export const hasGraphFragment = (hash: string): boolean => GRAPH_FRAGMENT_RE.test(hash);
+
+/**
  * Decode a `#graph=<encoded>` fragment into a resource map. Returns null when
- * the fragment is absent, empty, or malformed (never throws).
+ * the fragment is absent, empty, malformed, or not a valid create-only graph
+ * (never throws).
  */
 export const decodeGraphFragment = async (hash: string): Promise<ResourceMap | null> => {
     const match = GRAPH_FRAGMENT_RE.exec(hash);
@@ -58,11 +109,20 @@ export const decodeGraphFragment = async (hash: string): Promise<ResourceMap | n
     try {
         const bytes = base64urlToBytes(match[1]);
         const json = await bytesToText(bytes);
-        const map = JSON.parse(json) as ResourceMap;
-        if (map && typeof map === 'object' && Object.keys(map).length > 0) {
-            return map;
+        const parsed = JSON.parse(json);
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            return null;
         }
-        return null;
+        const entries = Object.entries(parsed);
+        if (entries.length === 0) {
+            return null;
+        }
+        // Reject the whole payload unless every resource is create-only and
+        // well-formed; a partial hydrate of a tampered graph is worse than none.
+        if (!entries.every(([id, value]) => isCreateOnlyResource(id, value))) {
+            return null;
+        }
+        return parsed as ResourceMap;
     } catch (error) {
         console.error('Failed to decode graph handoff fragment', error);
         return null;

--- a/core/src/main/resources/webapp/src/const/graphHandoff.ts
+++ b/core/src/main/resources/webapp/src/const/graphHandoff.ts
@@ -12,15 +12,20 @@ import { NEW_NODE_ID_PREFIX } from './constants';
  *
  * The fragment is never sent to the server, proxies, or logs and is not
  * included in the Referer header, so the graph stays client-side only. The
- * Builder decodes it and hydrates the workspace by reusing the same node-
- * injection path recipes use (see nodesFromResourceMap / addNodesToWorkspace).
+ * Builder decodes it into a *new* workspace tab by reusing the same node-
+ * injection path recipes use (see nodesFromResourceMap / addNodesToWorkspace),
+ * so it never clobbers the user's existing tabs, and the user still drives
+ * Plan -> Execute themselves.
  *
- * The handoff is create-only, and that is *enforced* here (see
- * isCreateOnlyResource), not merely documented: the fragment is attacker-
- * controllable (a crafted link) and the decoded graph flows straight into the
- * workspace and then Plan/Execute. Every resource must be a brand-new node
- * (temporary id, the same convention isNewNode uses) and may not request an
- * update or deletion of an existing resource.
+ * "Create-only" here is a *convention* for the trusted agent->user handoff, not
+ * a security guarantee, and isCreateOnlyResource is a sanity guard, not
+ * enforcement. Two reasons: the backend classifies each resource as a create or
+ * an update by database existence of its id (GraphEngine.planGraphUpdate), not
+ * by the tmp prefix; and a browser tab is not a security boundary — Execute runs
+ * against the same authenticated session regardless. The checks below just keep
+ * a trusted handoff aligned with how the Builder mints new nodes and stop a
+ * malformed payload from reaching the canvas. Enforcing create-only for
+ * untrusted or shareable links would require server-side validation.
  */
 export type ResourceMap = Record<string, INodeData>;
 
@@ -55,27 +60,30 @@ const bytesToText = async (bytes: Uint8Array): Promise<string> => {
 };
 
 /**
- * A handed-off resource must be a well-formed, create-only node:
- *  - a plain object keyed in the map by its own id,
- *  - a *temporary* id (NEW_NODE_ID_PREFIX) so the backend treats it as a create
- *    rather than an update/delete of an existing resource,
- *  - not a deletion (`deleted: true`),
- *  - carrying the fields we dereference to render a node and to Plan.
- * Anything else fails validation and causes the whole payload to be rejected,
- * so decodeGraphFragment returns null instead of letting a malformed or
- * destructive graph reach the workspace.
+ * Validate a handed-off resource. This does two jobs at once:
+ *  - Correctness: guarantees decodeGraphFragment never returns something that
+ *    throws later in nodesFromResourceMap — value must be a plain object keyed
+ *    by its own id, with the fields we dereference (resourceDefinitionClass to
+ *    render, desiredState to Plan).
+ *  - Create-only *convention* (a sanity guard, not enforcement — see the file
+ *    header): a temporary id (NEW_NODE_ID_PREFIX, matching how the Builder mints
+ *    new nodes) and no deletion.
+ * `deleted` must be absent or literally false; anything else is rejected,
+ * including the string "true", which Gson coerces to boolean server-side.
+ * A failing resource rejects the whole payload (decodeGraphFragment -> null).
  */
 const isCreateOnlyResource = (id: string, value: unknown): value is INodeData => {
     if (!value || typeof value !== 'object') {
         return false;
     }
     const r = value as Record<string, unknown>;
-    // create-only: temporary id that matches its map key.
+    // create-only convention: temporary id that matches its map key.
     if (typeof r.id !== 'string' || r.id !== id || !r.id.startsWith(NEW_NODE_ID_PREFIX)) {
         return false;
     }
-    // reject destructive/update intent — a create-only graph never deletes.
-    if (r.deleted === true) {
+    // no deletion. Accept only absent or literal false — reject e.g. "true"
+    // (string), which would survive Gson's boolean coercion on the server.
+    if ('deleted' in r && r.deleted !== false) {
         return false;
     }
     // shape required to render a node (type) and to Plan (desiredState).

--- a/core/src/main/resources/webapp/src/const/graphHandoff.ts
+++ b/core/src/main/resources/webapp/src/const/graphHandoff.ts
@@ -1,0 +1,82 @@
+import { INodeData, TNode } from './types';
+
+/**
+ * Agent -> Builder handoff.
+ *
+ * An agent can hand a user a create-only graph by encoding the same
+ * `Record<resourceId, resource>` map it would POST to /api/v2/graphs/plan and
+ * putting it in the URL *fragment* (the part after '#'), e.g.
+ *
+ *     /builder#graph=<base64url(gzip(JSON))>
+ *
+ * The fragment is never sent to the server, proxies, or logs and is not
+ * included in the Referer header, so the graph stays client-side only. The
+ * Builder decodes it and hydrates the workspace by reusing the same node-
+ * injection path recipes use (see nodesFromResourceMap / addNodesToWorkspace).
+ */
+export type ResourceMap = Record<string, INodeData>;
+
+const GRAPH_FRAGMENT_RE = /[#&]graph=([^&]+)/;
+
+// gzip streams start with the magic bytes 0x1f 0x8b.
+const isGzip = (bytes: Uint8Array): boolean =>
+    bytes.length > 2 && bytes[0] === 0x1f && bytes[1] === 0x8b;
+
+// base64url string -> raw bytes
+const base64urlToBytes = (value: string): Uint8Array => {
+    const b64 = value.replace(/-/g, '+').replace(/_/g, '/');
+    const binary = atob(b64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+};
+
+// Accepts both gzipped and plain (uncompressed) payloads so links stay
+// human-decodable in dev while real handoffs can compress. DecompressionStream
+// is reached via globalThis so this compiles even on TS lib versions whose
+// dom typings predate it; it is guarded for runtimes that lack the API.
+const bytesToText = async (bytes: Uint8Array): Promise<string> => {
+    const globalObj = globalThis as any;
+    if (isGzip(bytes) && typeof globalObj.DecompressionStream !== 'undefined') {
+        const stream = new Response(bytes).body!.pipeThrough(new globalObj.DecompressionStream('gzip'));
+        return new Response(stream as any).text();
+    }
+    return new TextDecoder().decode(bytes);
+};
+
+/**
+ * Decode a `#graph=<encoded>` fragment into a resource map. Returns null when
+ * the fragment is absent, empty, or malformed (never throws).
+ */
+export const decodeGraphFragment = async (hash: string): Promise<ResourceMap | null> => {
+    const match = GRAPH_FRAGMENT_RE.exec(hash);
+    if (!match) {
+        return null;
+    }
+    try {
+        const bytes = base64urlToBytes(match[1]);
+        const json = await bytesToText(bytes);
+        const map = JSON.parse(json) as ResourceMap;
+        if (map && typeof map === 'object' && Object.keys(map).length > 0) {
+            return map;
+        }
+        return null;
+    } catch (error) {
+        console.error('Failed to decode graph handoff fragment', error);
+        return null;
+    }
+};
+
+/**
+ * Turn a resource map into React Flow nodes. Mirrors the recipe load transform
+ * (RecipeModal.handleAddToWorkspace) so both share one code path.
+ */
+export const nodesFromResourceMap = (map: ResourceMap): TNode[] =>
+    Object.values(map).map((resource) => ({
+        position: { x: 0, y: 0 }, // will auto layout
+        type: resource.resourceDefinitionClass,
+        data: resource,
+        id: resource.id,
+    }));


### PR DESCRIPTION
## What

Adds the ability for a create-only `deltaGraph` to be handed to the Builder via the URL fragment:

  /builder#graph=<base64url( gzip | plain JSON )>

On load the Builder decodes the fragment, opens a fresh workspace tab, and injects the resources as nodes, reusing the same path recipes use (`addNodesToWorkspace`). The user reviews/edits and runs Plan → Execute themselves; nothing runs automatically.

## Why

I am working on an onboarding agent that builds the graph through conversation and questions, this PR bridges the gap to let a tool propose a ready-to-review graph and hand it to a human in the Builder to review before handing off to be reviewed. These changes involve no server round-trip and no new API with the human fully in the loop.

## Notes

- **New** `src/const/graphHandoff.ts`: `decodeGraphFragment` (handles gzip via native `DecompressionStream` and plain JSON; returns `null`, never throws, on malformed/empty input) and `nodesFromResourceMap` (mirrors `RecipeModal.handleAddToWorkspace`).
- **Changed** `BuilderView.tsx`: hydrates on load, then scrubs the payload from the URL via `history.replaceState`.
- **Security:** the graph rides in the URL *fragment*, which browsers never send to the server — it stays client-side and is stripped after hydration.
- **Backwards compatible:** no fragment → `decodeGraphFragment` returns `null` and the Builder behaves exactly as before.
- Decoded-payload size limits (gzip-bomb hardening) are intentionally deferred: the handoff is scoped to trusted agent-generated links opened by the user, so this belongs with server-side create-only enforcement if the feature is ever extended to untrusted or shareable links.
- Snacks are raised for successful and rejected imports to give the user insight into the status of operation.


## Testing

Manually verified in the Builder dev server: opening a `/builder#graph=...` URL hydrates the encoded resources as draggable nodes in a new tab, the fragment is cleared from the address bar, and Plan/Execute pick up the hydrated graph.
Confirmed both the gzipped and plain-JSON payload paths, and that a malformed or absent fragment is a clean no-op (no error, normal Builder).

I also wrote ts-jest unit tests locally covering the encode/decode round-trip (gzip + plain), malformed/empty → `null`, and node-transform parity with the recipe path. They're not included here since the project doesn't currently use jest, but I'd be  happy to add them (with the test setup) as a follow-up if that's wanted.
