### PR TITLE
Apply resource-definition defaults when hydrating #graph= handoff

### DIFF
--- a/core/src/main/resources/webapp/src/components/builder/BuilderView.tsx
+++ b/core/src/main/resources/webapp/src/components/builder/BuilderView.tsx
@@ -13,7 +13,12 @@ import {
     setOpenResourceEditor,
 } from '../../store/slice/builder';
 import { TNode } from '../../const/types';
-import { decodeGraphFragment, hasGraphFragment, nodesFromResourceMap } from '../../const/graphHandoff';
+import {
+    applyResourceDefaults,
+    decodeGraphFragment,
+    hasGraphFragment,
+    nodesFromResourceMap,
+} from '../../const/graphHandoff';
 import TopologyBuilder from '../../topology/TopologyBuilder';
 import { useSnackBar } from '../../context/SnackbarContext';
 import { useLoadingSpinner } from '../../context/LoadingSpinnerContext';
@@ -42,14 +47,17 @@ const BuilderView: React.FC<IBuilderViewProps> = () => {
     // Hydrate a create-only graph handed off via the URL fragment (#graph=...).
     // Gated on workspaceLoaded so we run *after* TopologyBuilder's onRestore has
     // set up a consistent tabs map + selectedTabId; running during mount races
-    // that restore and the injected nodes get dropped.
+    // that restore and the injected nodes get dropped. Also gated on
+    // resourceDefinitions so applyResourceDefaults has the schemas it needs to
+    // fill defaults — otherwise the injected nodes would miss form defaults (e.g.
+    // a topic's customConfigs) and fail Plan.
     useEffect(() => {
-        if (!workspaceLoaded || hydratedFromFragmentRef.current) {
+        if (!workspaceLoaded || !resourceDefinitions || hydratedFromFragmentRef.current) {
             return;
         }
         hydratedFromFragmentRef.current = true;
         hydrateFromFragment();
-    }, [workspaceLoaded]);
+    }, [workspaceLoaded, resourceDefinitions]);
 
     const fetchResourceDefinitions = () => {
         showLoadingOverlay(true);
@@ -115,7 +123,11 @@ const BuilderView: React.FC<IBuilderViewProps> = () => {
         }
         const map = await decodeGraphFragment(window.location.hash);
         if (map) {
-            const nodes = nodesFromResourceMap(map);
+            // Populate schema defaults (mirrors the Builder form) so a handoff
+            // node matches a form-built one; otherwise fields the backend Plan
+            // dereferences (e.g. a topic's customConfigs) can be absent.
+            const hydratedMap = applyResourceDefaults(map, resourceDefinitions);
+            const nodes = nodesFromResourceMap(hydratedMap);
             dispatch(addWorkspaceTab({ makeActive: true }));
             dispatch(addNodesToWorkspace({ nodes }));
             dispatch(setNodeToEdit(null));

--- a/core/src/main/resources/webapp/src/const/graphHandoff.ts
+++ b/core/src/main/resources/webapp/src/const/graphHandoff.ts
@@ -1,4 +1,5 @@
-import { INodeData, TNode } from './types';
+import { utils } from '@rjsf/core';
+import { INodeData, TNode, IResourceDefinitions } from './types';
 import { NEW_NODE_ID_PREFIX } from './constants';
 
 /**
@@ -135,6 +136,44 @@ export const decodeGraphFragment = async (hash: string): Promise<ResourceMap | n
         console.error('Failed to decode graph handoff fragment', error);
         return null;
     }
+};
+
+/**
+ * Fill each resource's `desiredState` with its type's JSON-schema defaults,
+ * mirroring what the Builder form (@rjsf) injects the moment a node is opened /
+ * "Update Plan" is clicked (NewNodePrompt). A handoff-injected node otherwise
+ * skips the form entirely, so schema-defaulted-but-absent fields (e.g. a
+ * PubSubTopic's `customConfigs`) are missing — and some resource Plans
+ * dereference those fields without a null check, turning an incomplete graph
+ * into a backend 500. Applying defaults here makes a handoff node byte-for-byte
+ * equivalent to a form-built one for every resource type, not just one field.
+ *
+ * getDefaultFormState only fills gaps, so any value already supplied in the
+ * handoff payload is preserved. Resources whose type is unknown to the current
+ * definitions are passed through untouched.
+ */
+export const applyResourceDefaults = (
+    map: ResourceMap,
+    resourceDefinitions: IResourceDefinitions | null
+): ResourceMap => {
+    const defs = resourceDefinitions?.resourceMap ?? {};
+    const out: ResourceMap = {};
+    for (const [id, resource] of Object.entries(map)) {
+        const cls = resource.resourceDefinitionClass;
+        const schema = cls ? defs[cls]?.configSchema : undefined;
+        if (schema) {
+            out[id] = {
+                ...resource,
+                desiredState: utils.getDefaultFormState(schema, resource.desiredState ?? {}, schema) as Record<
+                    string,
+                    unknown
+                >,
+            };
+        } else {
+            out[id] = resource;
+        }
+    }
+    return out;
 };
 
 /**


### PR DESCRIPTION
## Summary
- Handoff-injected nodes skip the rjsf form, so schema-default fields (e.g. a
  PubSubTopic's `customConfigs`) were absent. Resource Plans that dereference
  those fields without a null check turned an incomplete handoff graph into a
  backend 500.
- `applyResourceDefaults` populates each resource's `desiredState` with its
  type's JSON-schema defaults during `hydrateFromFragment`, so a handoff node
  matches a form-built one for every resource type — not just one field.
- Hydration now gates on both `workspaceLoaded` and `resourceDefinitions`.
- These changes are only relevant for the builder via graph url path

## Test plan
- [ ] Open a `#graph=` link whose topic omits `customConfigs`; confirm the node
      hydrates with `customConfigs: {}` and Plan no longer 500s.
