### PR TITLE
Add Helix Ultra onboarding agent button

### DIFF
--- a/core/src/main/resources/webapp/src/App.scss
+++ b/core/src/main/resources/webapp/src/App.scss
@@ -10,3 +10,41 @@ body {
 code {
     font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
 }
+
+.slate-helix-ultra-button {
+    position: fixed;
+    right: 24px;
+    // Clear React Flow's bottom-right 200x150 minimap and its 15px margin.
+    bottom: 180px;
+    z-index: 1300;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 18px;
+    border: 0;
+    border-radius: 28px;
+    background: #1a73e8;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+    color: #fff;
+    cursor: pointer;
+    font: inherit;
+    font-size: 15px;
+    font-weight: 600;
+    transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.slate-helix-ultra-button:hover {
+    background: #1765cc;
+    box-shadow: 0 8px 24px rgba(26, 115, 232, 0.45);
+    transform: translateY(-2px);
+}
+
+.slate-helix-ultra-button:focus-visible {
+    outline: 3px solid rgba(255, 255, 255, 0.9);
+    outline-offset: 2px;
+}
+
+.slate-helix-ultra-button__icon {
+    font-size: 18px;
+    line-height: 1;
+}

--- a/core/src/main/resources/webapp/src/App.tsx
+++ b/core/src/main/resources/webapp/src/App.tsx
@@ -11,6 +11,7 @@ import { Link as RouterLink, Navigate, Routes, Route, useParams } from 'react-ro
 import { useStyles } from './AppStyles';
 import MgmtView from './topology/MgmtView';
 import ResourceSearch from './components/common/ResourceSearch';
+import HelixUltraButton from './components/common/HelixUltraButton';
 import 'reactflow/dist/style.css';
 import './App.scss';
 
@@ -136,6 +137,7 @@ const App: React.FC<ISlateAppProps> = () => {
                     <Route path={'/mgmt'} element={<MgmtView />} />
                 </Routes>
             </Box>
+            <HelixUltraButton />
         </Box>
     );
 };

--- a/core/src/main/resources/webapp/src/components/common/HelixUltraButton.tsx
+++ b/core/src/main/resources/webapp/src/components/common/HelixUltraButton.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+const SLATE_ONBOARDING_AGENT_ID = '019f94de-ede7-7968-9397-7c300ca49a69';
+
+const HelixUltraButton: React.FC = () => (
+    <button
+        type="button"
+        className="helix-ultra-button slate-helix-ultra-button"
+        data-agent-id={SLATE_ONBOARDING_AGENT_ID}
+        data-button-name="Ask Slate Agent"
+        data-create-new-chat="true"
+        data-initial-placeholder-text="Ask about onboarding to Slate..."
+        aria-label="Ask Slate Agent"
+        title="Ask Slate Agent — requires the Helix Ultra browser extension"
+    >
+        <span className="slate-helix-ultra-button__icon" aria-hidden="true">
+            ✨
+        </span>
+        Ask Slate Agent
+    </button>
+);
+
+export default HelixUltraButton;


### PR DESCRIPTION
## Summary

### Problem (Why)

Slate users currently have to leave the application and navigate to Helix to get onboarding help. This makes the onboarding workflow harder to discover and interrupts work in the Builder.

### Solution (What + How)

Add a fixed, accessible “Ask Slate Agent” button to the application shell. The button follows Helix Ultra's webapp integration contract and supplies the Slate onboarding agent ID, so the browser extension opens a fresh sidebar chat with that agent. Its placement clears the React Flow minimap while remaining visible across Slate routes.

## Screenshots

### Button placement

![Ask Slate Agent button](https://raw.githubusercontent.com/aiden-lee11/slate/pr-29-assets/docs/pr-assets/helix-ultra-button.png)

### Helix Ultra sidebar

![Slate onboarding agent in Helix Ultra](https://raw.githubusercontent.com/aiden-lee11/slate/pr-29-assets/docs/pr-assets/helix-ultra-sidebar.png)

## Test Plan

- Ran `npx tsc --noEmit` successfully.
- Ran `npx eslint src/components/common/HelixUltraButton.tsx` successfully.
- Manually verified that the button opens Helix Ultra and routes to the configured agent. Helix Ultra 1.3.6 has an external cold-start race where the first click can open generic chat; a second click routes correctly.
- Attempted `npm run build`; the local environment is blocked by Node Sass 6 not supporting Node runtime 137.

Made with [Cursor](https://cursor.com)