### PR TITLE
Show onboarding button only in Builder

### DIFF
--- a/core/src/main/resources/webapp/src/App.tsx
+++ b/core/src/main/resources/webapp/src/App.tsx
@@ -11,7 +11,6 @@ import { Link as RouterLink, Navigate, Routes, Route, useParams } from 'react-ro
 import { useStyles } from './AppStyles';
 import MgmtView from './topology/MgmtView';
 import ResourceSearch from './components/common/ResourceSearch';
-import OnboardingButton from './components/common/OnboardingButton';
 import 'reactflow/dist/style.css';
 import './App.scss';
 
@@ -137,7 +136,6 @@ const App: React.FC<ISlateAppProps> = () => {
                     <Route path={'/mgmt'} element={<MgmtView />} />
                 </Routes>
             </Box>
-            <OnboardingButton />
         </Box>
     );
 };

--- a/core/src/main/resources/webapp/src/components/builder/BuilderView.tsx
+++ b/core/src/main/resources/webapp/src/components/builder/BuilderView.tsx
@@ -26,6 +26,7 @@ import { WorkspaceElementsProvider } from './context/WorkspaceElementsContext';
 import Sidebar from './Sidebar';
 import { Box } from '@mui/material';
 import ReceipeModal from './recipe/RecipeModal';
+import OnboardingButton from '../common/OnboardingButton';
 
 interface IBuilderViewProps {}
 
@@ -174,6 +175,7 @@ const BuilderView: React.FC<IBuilderViewProps> = () => {
                 </ReactFlowProvider>
             </Box>
             <ReceipeModal open={searchParams.has('recipe')} recipeName={searchParams.get('recipe')} />
+            <OnboardingButton />
         </React.Fragment>
     );
 };


### PR DESCRIPTION
## Summary

### Problem (Why)

The onboarding button was rendered by the global app layout, causing it to appear on Tasks, Executions, Resources, and other non-Builder pages.

### Solution (What + How)

Render the onboarding button inside `BuilderView` so it is mounted only for Builder routes, including resource-specific Builder URLs.

## Test Plan

- Confirmed the production bundle reaches application compilation; the local build remains blocked by the existing Node Sass incompatibility with Node runtime 137.
- Confirmed targeted lint reports only pre-existing warnings and empty-interface errors.

Made with [Cursor](https://cursor.com)