### PR TITLE
Add permission-aware execution approvals

### DIFF
--- a/commons/src/main/java/com/pinterest/slate/SlateConfig.java
+++ b/commons/src/main/java/com/pinterest/slate/SlateConfig.java
@@ -78,12 +78,23 @@ public class SlateConfig extends Configuration {
 
   private Map<String, String> onboardingButton = Collections.emptyMap();
 
+  private Map<String, String> approvalReviewButton = Collections.emptyMap();
+
   public Map<String, String> getOnboardingButton() {
     return onboardingButton;
   }
 
   public void setOnboardingButton(Map<String, String> onboardingButton) {
     this.onboardingButton = onboardingButton == null ? Collections.emptyMap() : onboardingButton;
+  }
+
+  public Map<String, String> getApprovalReviewButton() {
+    return approvalReviewButton;
+  }
+
+  public void setApprovalReviewButton(Map<String, String> approvalReviewButton) {
+    this.approvalReviewButton =
+        approvalReviewButton == null ? Collections.emptyMap() : approvalReviewButton;
   }
 
   public String getBaseMetricsUrl() {

--- a/core/src/main/java/com/pinterest/slate/api/SlateMgmtApi.java
+++ b/core/src/main/java/com/pinterest/slate/api/SlateMgmtApi.java
@@ -60,6 +60,12 @@ public class SlateMgmtApi {
     return config.getOnboardingButton();
   }
 
+  @Path("/approval-review-button")
+  @GET
+  public Map<String, String> getApprovalReviewButton() {
+    return config.getApprovalReviewButton();
+  }
+
   @Path("/isadmin")
   @GET
   public boolean isUserAdmin(@Context SecurityContext sc,

--- a/core/src/main/resources/webapp/src/components/common/OnboardingButton.tsx
+++ b/core/src/main/resources/webapp/src/components/common/OnboardingButton.tsx
@@ -5,6 +5,7 @@ type OnboardingButtonConfig = Record<string, string>;
 
 const SAFE_ATTRIBUTE_PATTERN = /^(data|aria)-[a-z0-9_.:-]+$/;
 const SAFE_CLASS_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const DEFAULT_PRE_PROMPT = 'Help me onboard a data pipeline';
 
 const OnboardingButton: React.FC = () => {
     const [config, setConfig] = useState<OnboardingButtonConfig>({});
@@ -49,14 +50,18 @@ const OnboardingButton: React.FC = () => {
         .split(/\s+/)
         .filter((name) => SAFE_CLASS_NAME_PATTERN.test(name))
         .join(' ');
+    const buttonAttributes: Record<string, string> = {
+        ...safeAttributes,
+        'data-pre-prompt': safeAttributes['data-pre-prompt'] ?? DEFAULT_PRE_PROMPT,
+    };
 
     return (
         <Fab
             variant="extended"
             color="primary"
             className={safeClassName}
-            {...safeAttributes}
-            aria-label={safeAttributes['aria-label'] ?? label}
+            {...buttonAttributes}
+            aria-label={buttonAttributes['aria-label'] ?? label}
             title={title}
             style={{
                 position: 'fixed',

--- a/core/src/main/resources/webapp/src/components/execution/ApprovalReviewButton.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/ApprovalReviewButton.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Button } from '@mui/material';
+
+type ApprovalReviewButtonConfig = Record<string, string>;
+
+const SAFE_ATTRIBUTE_PATTERN = /^(data|aria)-[a-z0-9_.:-]+$/;
+const SAFE_CLASS_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const URL_PLACEHOLDER = '{url}';
+
+const ApprovalReviewButton: React.FC = () => {
+    const [config, setConfig] = useState<ApprovalReviewButtonConfig>({});
+
+    useEffect(() => {
+        let mounted = true;
+
+        fetch('/api/v2/mgmt/approval-review-button')
+            .then((response) => (response.ok ? response.json() : {}))
+            .then((data) => {
+                if (
+                    mounted &&
+                    data &&
+                    typeof data === 'object' &&
+                    !Array.isArray(data) &&
+                    Object.values(data).every((value) => typeof value === 'string')
+                ) {
+                    setConfig(data as ApprovalReviewButtonConfig);
+                }
+            })
+            .catch(() => {
+                // The approval review button is optional.
+            });
+
+        return () => {
+            mounted = false;
+        };
+    }, []);
+
+    const { label, title, className = '', ...attributes } = config;
+    if (!label) {
+        return null;
+    }
+
+    const safeAttributes = Object.entries(attributes).reduce<Record<string, string>>((result, [name, value]) => {
+        if (SAFE_ATTRIBUTE_PATTERN.test(name) && typeof value === 'string') {
+            result[name] =
+                name === 'data-pre-prompt' ? value.split(URL_PLACEHOLDER).join(window.location.href) : value;
+        }
+        return result;
+    }, {});
+    const safeClassName = className
+        .split(/\s+/)
+        .filter((name) => SAFE_CLASS_NAME_PATTERN.test(name))
+        .join(' ');
+
+    return (
+        <Box display="flex" justifyContent="flex-end" marginBottom={1}>
+            <Button
+                className={safeClassName}
+                {...safeAttributes}
+                aria-label={safeAttributes['aria-label'] ?? label}
+                title={title}
+                variant="outlined"
+                color="primary"
+                size="small"
+                sx={{ textTransform: 'none' }}
+            >
+                {label}
+            </Button>
+        </Box>
+    );
+};
+
+export default ApprovalReviewButton;

--- a/core/src/main/resources/webapp/src/components/execution/ExecPlanJsonDiff.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/ExecPlanJsonDiff.tsx
@@ -9,6 +9,30 @@ interface IExecPlanJsonDiffProps {
     execPlan: Record<string, IExecutionPlan>;
 }
 
+interface IResourceJsonDiffProps {
+    plan: IExecutionPlan;
+    splitView?: boolean;
+}
+
+export const ResourceJsonDiff: React.FC<IResourceJsonDiffProps> = ({ plan, splitView = true }) => {
+    const [oldValue, newValue] = useMemo(() => {
+        const oldObject = plan.currentResource ? sortObjectByKeys(plan.currentResource, true) : null;
+        const newObject = sortObjectByKeys(plan.proposedResource, true);
+        return [oldObject ? JSON.stringify(oldObject, null, 2) : '', JSON.stringify(newObject, null, 2)];
+    }, [plan]);
+
+    return (
+        <ReactDiffViewer
+            oldValue={oldValue}
+            newValue={newValue}
+            splitView={splitView}
+            hideLineNumbers={true}
+            showDiffOnly={true}
+            compareMethod={DiffMethod.WORDS}
+        />
+    );
+};
+
 const ExecPlanJsonDiff: React.FC<IExecPlanJsonDiffProps> = ({ execPlan }) => {
     const newAndExistingResources: [IExecutionPlan[], IExecutionPlan[]] = useMemo(() => {
         const newList: IExecutionPlan[] = [];
@@ -44,14 +68,7 @@ const ExecPlanJsonDiff: React.FC<IExecPlanJsonDiffProps> = ({ execPlan }) => {
                     </Box>
                 </AccordionSummary>
                 <AccordionDetails>
-                    <ReactDiffViewer
-                        oldValue={oldObject ? JSON.stringify(oldObject, null, 2) : ''}
-                        newValue={JSON.stringify(newObject, null, 2)}
-                        splitView={true}
-                        hideLineNumbers={true}
-                        showDiffOnly={true}
-                        compareMethod={DiffMethod.WORDS}
-                    />
+                    <ResourceJsonDiff plan={plan} />
                 </AccordionDetails>
             </Accordion>
         );

--- a/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
@@ -9,6 +9,7 @@ import { getExecutionApprovals } from './approvalUtils';
 import { ResourceJsonDiff } from './ExecPlanJsonDiff';
 
 const TASK_REFRESH_FREQUENCY = 5000;
+const APPROVAL_REVIEW_AGENT_ID = '019fde25-c4b0-747d-8e23-937e37c486da';
 
 interface IExecutionApprovalsProps {
     plan: Record<string, IExecutionPlan>;
@@ -51,7 +52,7 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan }) => {
         });
         return byResourceId;
     }, [plan]);
-    const reviewPrompt = `/internal/summarize-slate-approvals ${window.location.href}`;
+    const reviewPrompt = `summarize : ${window.location.href}`;
     const blockedCount = approvals.filter(
         (approval) => approval.status === 'NOT_STARTED' && approval.blockedBy.length > 0
     ).length;
@@ -150,7 +151,8 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan }) => {
             <Box display="flex" justifyContent="flex-end" marginBottom={1}>
                 <Button
                     className="helix-ultra-button"
-                    data-button-name="Review Slate Changes"
+                    data-agent-id={APPROVAL_REVIEW_AGENT_ID}
+                    data-button-name="Review with agent"
                     data-pre-prompt={reviewPrompt}
                     data-initial-placeholder-text="Ask about this Slate execution"
                     data-create-new-chat="true"

--- a/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
@@ -32,6 +32,7 @@ const statusDisplay = (status: TExecutionStatus): { label: string; color: 'defau
 const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan }) => {
     const { showSnackbar } = useSnackBar();
     const approvals = useMemo(() => getExecutionApprovals(plan), [plan]);
+    const reviewPrompt = `/internal/summarize-slate-approvals ${window.location.href}`;
     const [actionableTasks, setActionableTasks] = useState<Set<string>>(new Set());
     const [actionsUnavailable, setActionsUnavailable] = useState(false);
     const [updatingTask, setUpdatingTask] = useState<null | string>(null);
@@ -105,72 +106,86 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan }) => {
             });
     };
 
-    if (!approvals.length) {
-        return (
-            <Typography mt={2} align="center" variant="subtitle1">
-                No approvals are required for this execution
-            </Typography>
-        );
-    }
-
     return (
         <Box height="100%" overflow="auto" paddingTop={1}>
+            <Box display="flex" justifyContent="flex-end" marginBottom={1}>
+                <Button
+                    className="helix-ultra-button"
+                    data-button-name="Review Slate Changes"
+                    data-pre-prompt={reviewPrompt}
+                    data-initial-placeholder-text="Ask about this Slate execution"
+                    data-create-new-chat="true"
+                    variant="outlined"
+                    color="primary"
+                    size="small"
+                    title="Open Helix Ultra to review this execution"
+                    sx={{ textTransform: 'none' }}
+                >
+                    Review changes
+                </Button>
+            </Box>
             {actionsUnavailable && (
                 <Alert severity="warning" sx={{ marginBottom: 1 }}>
                     Approval actions are temporarily unavailable.
                 </Alert>
             )}
-            <Stack spacing={1}>
-                {approvals.map((approval) => {
-                    const key = taskKey(approval.processId, approval.taskId);
-                    const canAct = actionableTasks.has(key);
-                    const isUpdating = updatingTask === key;
-                    const status = statusDisplay(approval.status);
+            {!approvals.length ? (
+                <Typography mt={2} align="center" variant="subtitle1">
+                    No approvals are required for this execution
+                </Typography>
+            ) : (
+                <Stack spacing={1}>
+                    {approvals.map((approval) => {
+                        const key = taskKey(approval.processId, approval.taskId);
+                        const canAct = actionableTasks.has(key);
+                        const isUpdating = updatingTask === key;
+                        const status = statusDisplay(approval.status);
 
-                    return (
-                        <Box key={key} border={1} borderColor="divider" borderRadius={1} padding={1.5}>
-                            <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={1}>
-                                <Box minWidth={0}>
-                                    <Typography variant="subtitle1">
-                                        <b>{approval.summary}</b>
-                                    </Typography>
-                                    <Typography variant="body2" color="text.secondary">
-                                        Approval group: {approval.group || 'Unknown'}
-                                    </Typography>
-                                </Box>
-                                <Chip size="small" label={status.label} color={status.color} />
-                            </Stack>
-                            {approval.description && (
-                                <Box mt={1}>
-                                    <ReactMarkdown>{approval.description}</ReactMarkdown>
-                                </Box>
-                            )}
-                            {canAct && (
-                                <Stack direction="row" spacing={1} mt={1}>
-                                    <Button
-                                        size="small"
-                                        variant="outlined"
-                                        color="success"
-                                        disabled={isUpdating}
-                                        onClick={() => updateTask(approval.processId, approval.taskId, 'SUCCEEDED')}
-                                    >
-                                        Approve
-                                    </Button>
-                                    <Button
-                                        size="small"
-                                        variant="outlined"
-                                        color="error"
-                                        disabled={isUpdating}
-                                        onClick={() => updateTask(approval.processId, approval.taskId, 'FAILED')}
-                                    >
-                                        Deny
-                                    </Button>
+                        return (
+                            <Box key={key} border={1} borderColor="divider" borderRadius={1} padding={1.5}>
+                                <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={1}>
+                                    <Box minWidth={0}>
+                                        <Typography variant="subtitle1">
+                                            <b>{approval.summary}</b>
+                                        </Typography>
+                                        <Typography variant="body2" color="text.secondary">
+                                            Approval group: {approval.group || 'Unknown'}
+                                        </Typography>
+                                    </Box>
+                                    <Chip size="small" label={status.label} color={status.color} />
                                 </Stack>
-                            )}
-                        </Box>
-                    );
-                })}
-            </Stack>
+                                {approval.description && (
+                                    <Box mt={1}>
+                                        <ReactMarkdown>{approval.description}</ReactMarkdown>
+                                    </Box>
+                                )}
+                                {canAct && (
+                                    <Stack direction="row" spacing={1} mt={1}>
+                                        <Button
+                                            size="small"
+                                            variant="outlined"
+                                            color="success"
+                                            disabled={isUpdating}
+                                            onClick={() => updateTask(approval.processId, approval.taskId, 'SUCCEEDED')}
+                                        >
+                                            Approve
+                                        </Button>
+                                        <Button
+                                            size="small"
+                                            variant="outlined"
+                                            color="error"
+                                            disabled={isUpdating}
+                                            onClick={() => updateTask(approval.processId, approval.taskId, 'FAILED')}
+                                        >
+                                            Deny
+                                        </Button>
+                                    </Stack>
+                                )}
+                            </Box>
+                        );
+                    })}
+                </Stack>
+            )}
         </Box>
     );
 };

--- a/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
@@ -1,0 +1,178 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Alert, Box, Button, Chip, Stack, Typography } from '@mui/material';
+import ReactMarkdown from 'react-markdown';
+import { useSnackBar } from '../../context/SnackbarContext';
+import { ITask } from '../task/types';
+import { IExecutionPlan, TExecutionStatus } from './types';
+import { getExecutionApprovals } from './approvalUtils';
+
+const TASK_REFRESH_FREQUENCY = 5000;
+
+interface IExecutionApprovalsProps {
+    plan: Record<string, IExecutionPlan>;
+}
+
+const taskKey = (processId: string, taskId: string): string => `${processId}:${taskId}`;
+
+const statusDisplay = (status: TExecutionStatus): { label: string; color: 'default' | 'error' | 'success' | 'warning' } => {
+    switch (status) {
+        case 'SUCCEEDED':
+            return { label: 'Approved', color: 'success' };
+        case 'FAILED':
+            return { label: 'Denied / failed', color: 'error' };
+        case 'RUNNING':
+            return { label: 'Awaiting approval', color: 'warning' };
+        case 'CANCELLED':
+            return { label: 'Cancelled', color: 'default' };
+        default:
+            return { label: 'Not started', color: 'default' };
+    }
+};
+
+const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan }) => {
+    const { showSnackbar } = useSnackBar();
+    const approvals = useMemo(() => getExecutionApprovals(plan), [plan]);
+    const [actionableTasks, setActionableTasks] = useState<Set<string>>(new Set());
+    const [actionsUnavailable, setActionsUnavailable] = useState(false);
+    const [updatingTask, setUpdatingTask] = useState<null | string>(null);
+
+    const fetchActionableTasks = useCallback(() => {
+        fetch('/api/v2/tasks/mygrouptasks', {
+            method: 'GET',
+        })
+            .then((response) => {
+                if (!response.ok) {
+                    throw Error(response.statusText);
+                }
+                return response.json();
+            })
+            .then((tasks: ITask[]) => {
+                setActionableTasks(
+                    new Set(
+                        tasks
+                            .filter((task) => task.taskType === 'APPROVAL')
+                            .map((task) => taskKey(task.processId, task.taskId))
+                    )
+                );
+                setActionsUnavailable(false);
+            })
+            .catch((error) => {
+                console.error('Unable to load approval permissions', error);
+                setActionableTasks(new Set());
+                setActionsUnavailable(true);
+            });
+    }, []);
+
+    useEffect(() => {
+        fetchActionableTasks();
+        const intervalId = setInterval(fetchActionableTasks, TASK_REFRESH_FREQUENCY);
+        return () => clearInterval(intervalId);
+    }, [fetchActionableTasks]);
+
+    const updateTask = (processId: string, taskId: string, status: 'SUCCEEDED' | 'FAILED') => {
+        const key = taskKey(processId, taskId);
+        setUpdatingTask(key);
+        fetch(
+            `/api/v2/tasks/${encodeURIComponent(processId)}/${encodeURIComponent(taskId)}/${encodeURIComponent(status)}`,
+            {
+                method: 'PUT',
+            }
+        )
+            .then((response) => {
+                if (!response.ok) {
+                    throw Error(response.statusText);
+                }
+                setActionableTasks((current) => {
+                    const next = new Set(current);
+                    next.delete(key);
+                    return next;
+                });
+                showSnackbar({
+                    type: 'success',
+                    message: status === 'SUCCEEDED' ? 'Approval submitted' : 'Denial submitted',
+                });
+            })
+            .catch((error) => {
+                console.error('Unable to update approval', error);
+                showSnackbar({
+                    type: 'error',
+                    message: 'Unable to update approval',
+                });
+                fetchActionableTasks();
+            })
+            .finally(() => {
+                setUpdatingTask(null);
+            });
+    };
+
+    if (!approvals.length) {
+        return (
+            <Typography mt={2} align="center" variant="subtitle1">
+                No approvals are required for this execution
+            </Typography>
+        );
+    }
+
+    return (
+        <Box height="100%" overflow="auto" paddingTop={1}>
+            {actionsUnavailable && (
+                <Alert severity="warning" sx={{ marginBottom: 1 }}>
+                    Approval actions are temporarily unavailable.
+                </Alert>
+            )}
+            <Stack spacing={1}>
+                {approvals.map((approval) => {
+                    const key = taskKey(approval.processId, approval.taskId);
+                    const canAct = actionableTasks.has(key);
+                    const isUpdating = updatingTask === key;
+                    const status = statusDisplay(approval.status);
+
+                    return (
+                        <Box key={key} border={1} borderColor="divider" borderRadius={1} padding={1.5}>
+                            <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={1}>
+                                <Box minWidth={0}>
+                                    <Typography variant="subtitle1">
+                                        <b>{approval.summary}</b>
+                                    </Typography>
+                                    <Typography variant="body2" color="text.secondary">
+                                        Approval group: {approval.group || 'Unknown'}
+                                    </Typography>
+                                </Box>
+                                <Chip size="small" label={status.label} color={status.color} />
+                            </Stack>
+                            {approval.description && (
+                                <Box mt={1}>
+                                    <ReactMarkdown>{approval.description}</ReactMarkdown>
+                                </Box>
+                            )}
+                            {canAct && (
+                                <Stack direction="row" spacing={1} mt={1}>
+                                    <Button
+                                        size="small"
+                                        variant="outlined"
+                                        color="success"
+                                        disabled={isUpdating}
+                                        onClick={() => updateTask(approval.processId, approval.taskId, 'SUCCEEDED')}
+                                    >
+                                        Approve
+                                    </Button>
+                                    <Button
+                                        size="small"
+                                        variant="outlined"
+                                        color="error"
+                                        disabled={isUpdating}
+                                        onClick={() => updateTask(approval.processId, approval.taskId, 'FAILED')}
+                                    >
+                                        Deny
+                                    </Button>
+                                </Stack>
+                            )}
+                        </Box>
+                    );
+                })}
+            </Stack>
+        </Box>
+    );
+};
+
+export default ExecutionApprovals;

--- a/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Alert, Box, Button, Chip, Stack, Typography } from '@mui/material';
+import { Alert, alpha, Box, Button, Chip, Stack, Typography, useTheme } from '@mui/material';
 import ReactMarkdown from 'react-markdown';
 import { useSnackBar } from '../../context/SnackbarContext';
 import { ITask } from '../task/types';
@@ -14,14 +14,20 @@ interface IExecutionApprovalsProps {
 
 const taskKey = (processId: string, taskId: string): string => `${processId}:${taskId}`;
 
-const statusDisplay = (status: TExecutionStatus): { label: string; color: 'default' | 'error' | 'success' | 'warning' } => {
+const statusDisplay = (
+    status: TExecutionStatus,
+    blocked: boolean
+): { label: string; color: 'default' | 'error' | 'info' | 'success' | 'warning' } => {
+    if (blocked) {
+        return { label: 'Blocked', color: 'warning' };
+    }
     switch (status) {
         case 'SUCCEEDED':
             return { label: 'Approved', color: 'success' };
         case 'FAILED':
             return { label: 'Denied / failed', color: 'error' };
         case 'RUNNING':
-            return { label: 'Awaiting approval', color: 'warning' };
+            return { label: 'Awaiting approval', color: 'info' };
         case 'CANCELLED':
             return { label: 'Cancelled', color: 'default' };
         default:
@@ -31,8 +37,16 @@ const statusDisplay = (status: TExecutionStatus): { label: string; color: 'defau
 
 const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan }) => {
     const { showSnackbar } = useSnackBar();
+    const theme = useTheme();
     const approvals = useMemo(() => getExecutionApprovals(plan), [plan]);
     const reviewPrompt = `/internal/summarize-slate-approvals ${window.location.href}`;
+    const blockedCount = approvals.filter(
+        (approval) => approval.status === 'NOT_STARTED' && approval.blockedBy.length > 0
+    ).length;
+    const awaitingCount = approvals.filter(
+        (approval) => approval.status === 'RUNNING' && approval.blockedBy.length === 0
+    ).length;
+    const approvedCount = approvals.filter((approval) => approval.status === 'SUCCEEDED').length;
     const [actionableTasks, setActionableTasks] = useState<Set<string>>(new Set());
     const [actionsUnavailable, setActionsUnavailable] = useState(false);
     const [updatingTask, setUpdatingTask] = useState<null | string>(null);
@@ -134,57 +148,87 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan }) => {
                     No approvals are required for this execution
                 </Typography>
             ) : (
-                <Stack spacing={1}>
-                    {approvals.map((approval) => {
-                        const key = taskKey(approval.processId, approval.taskId);
-                        const canAct = actionableTasks.has(key);
-                        const isUpdating = updatingTask === key;
-                        const status = statusDisplay(approval.status);
+                <>
+                    <Typography variant="body2" color="text.secondary" marginBottom={1}>
+                        {awaitingCount} awaiting · {blockedCount} blocked · {approvedCount} approved
+                    </Typography>
+                    <Stack spacing={1}>
+                        {approvals.map((approval) => {
+                            const key = taskKey(approval.processId, approval.taskId);
+                            const canAct = actionableTasks.has(key);
+                            const isUpdating = updatingTask === key;
+                            const isBlocked = approval.status === 'NOT_STARTED' && approval.blockedBy.length > 0;
+                            const status = statusDisplay(approval.status, isBlocked);
 
-                        return (
-                            <Box key={key} border={1} borderColor="divider" borderRadius={1} padding={1.5}>
-                                <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={1}>
-                                    <Box minWidth={0}>
-                                        <Typography variant="subtitle1">
-                                            <b>{approval.summary}</b>
-                                        </Typography>
-                                        <Typography variant="body2" color="text.secondary">
-                                            Approval group: {approval.group || 'Unknown'}
-                                        </Typography>
-                                    </Box>
-                                    <Chip size="small" label={status.label} color={status.color} />
-                                </Stack>
-                                {approval.description && (
-                                    <Box mt={1}>
-                                        <ReactMarkdown>{approval.description}</ReactMarkdown>
-                                    </Box>
-                                )}
-                                {canAct && (
-                                    <Stack direction="row" spacing={1} mt={1}>
-                                        <Button
-                                            size="small"
-                                            variant="outlined"
-                                            color="success"
-                                            disabled={isUpdating}
-                                            onClick={() => updateTask(approval.processId, approval.taskId, 'SUCCEEDED')}
-                                        >
-                                            Approve
-                                        </Button>
-                                        <Button
-                                            size="small"
-                                            variant="outlined"
-                                            color="error"
-                                            disabled={isUpdating}
-                                            onClick={() => updateTask(approval.processId, approval.taskId, 'FAILED')}
-                                        >
-                                            Deny
-                                        </Button>
+                            return (
+                                <Box key={key} border={1} borderColor="divider" borderRadius={1} padding={1.5}>
+                                    <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing={1}>
+                                        <Box minWidth={0}>
+                                            <Typography variant="subtitle1" sx={{ overflowWrap: 'anywhere' }}>
+                                                <b>{approval.summary}</b>
+                                            </Typography>
+                                            <Typography variant="body2" color="text.secondary">
+                                                Stage {approval.dependencyLevel + 1} · Approval group:{' '}
+                                                {approval.group || 'Unknown'}
+                                            </Typography>
+                                        </Box>
+                                        <Chip size="small" label={status.label} color={status.color} />
                                     </Stack>
-                                )}
-                            </Box>
-                        );
-                    })}
-                </Stack>
+                                    {isBlocked && (
+                                        <Box
+                                            mt={1}
+                                            padding={1}
+                                            bgcolor={alpha(theme.palette.warning.main, 0.12)}
+                                            borderLeft={2}
+                                            borderColor="warning.main"
+                                        >
+                                            <Typography variant="body2" sx={{ overflowWrap: 'anywhere' }}>
+                                                <b>Waiting for:</b> {approval.blockedBy[0].label}
+                                            </Typography>
+                                            {approval.blockedBy.length > 1 && (
+                                                <Typography variant="caption" color="text.secondary">
+                                                    +{approval.blockedBy.length - 1} additional direct blocker
+                                                    {approval.blockedBy.length > 2 ? 's' : ''}
+                                                </Typography>
+                                            )}
+                                        </Box>
+                                    )}
+                                    {approval.description && (
+                                        <Box mt={1}>
+                                            <ReactMarkdown>{approval.description}</ReactMarkdown>
+                                        </Box>
+                                    )}
+                                    {canAct && !isBlocked && (
+                                        <Stack direction="row" spacing={1} mt={1}>
+                                            <Button
+                                                size="small"
+                                                variant="outlined"
+                                                color="success"
+                                                disabled={isUpdating}
+                                                onClick={() =>
+                                                    updateTask(approval.processId, approval.taskId, 'SUCCEEDED')
+                                                }
+                                            >
+                                                Approve
+                                            </Button>
+                                            <Button
+                                                size="small"
+                                                variant="outlined"
+                                                color="error"
+                                                disabled={isUpdating}
+                                                onClick={() =>
+                                                    updateTask(approval.processId, approval.taskId, 'FAILED')
+                                                }
+                                            >
+                                                Deny
+                                            </Button>
+                                        </Stack>
+                                    )}
+                                </Box>
+                            );
+                        })}
+                    </Stack>
+                </>
             )}
         </Box>
     );

--- a/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
@@ -160,7 +160,7 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan }) => {
                     title="Open Helix Ultra to review this execution"
                     sx={{ textTransform: 'none' }}
                 >
-                    Review changes
+                    Review with agent
                 </Button>
             </Box>
             {actionsUnavailable && (

--- a/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
@@ -1,10 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Alert, alpha, Box, Button, Chip, Stack, Typography, useTheme } from '@mui/material';
+import { Alert, alpha, Box, Button, Chip, Collapse, Stack, Typography, useTheme } from '@mui/material';
+import { KeyboardArrowDown, KeyboardArrowUp } from '@mui/icons-material';
 import ReactMarkdown from 'react-markdown';
 import { useSnackBar } from '../../context/SnackbarContext';
 import { ITask } from '../task/types';
 import { IExecutionPlan, TExecutionStatus } from './types';
 import { getExecutionApprovals } from './approvalUtils';
+import { ResourceJsonDiff } from './ExecPlanJsonDiff';
 
 const TASK_REFRESH_FREQUENCY = 5000;
 
@@ -39,6 +41,16 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan }) => {
     const { showSnackbar } = useSnackBar();
     const theme = useTheme();
     const approvals = useMemo(() => getExecutionApprovals(plan), [plan]);
+    const resourcePlans = useMemo(() => {
+        const byResourceId = new Map<string, IExecutionPlan>();
+        Object.entries(plan).forEach(([planId, planEntry]) => {
+            byResourceId.set(planId, planEntry);
+            if (planEntry.proposedResource?.id) {
+                byResourceId.set(planEntry.proposedResource.id, planEntry);
+            }
+        });
+        return byResourceId;
+    }, [plan]);
     const reviewPrompt = `/internal/summarize-slate-approvals ${window.location.href}`;
     const blockedCount = approvals.filter(
         (approval) => approval.status === 'NOT_STARTED' && approval.blockedBy.length > 0
@@ -50,6 +62,7 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan }) => {
     const [actionableTasks, setActionableTasks] = useState<Set<string>>(new Set());
     const [actionsUnavailable, setActionsUnavailable] = useState(false);
     const [updatingTask, setUpdatingTask] = useState<null | string>(null);
+    const [expandedChanges, setExpandedChanges] = useState<Set<string>>(new Set());
 
     const fetchActionableTasks = useCallback(() => {
         fetch('/api/v2/tasks/mygrouptasks', {
@@ -120,6 +133,18 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan }) => {
             });
     };
 
+    const toggleChanges = (key: string) => {
+        setExpandedChanges((current) => {
+            const next = new Set(current);
+            if (next.has(key)) {
+                next.delete(key);
+            } else {
+                next.add(key);
+            }
+            return next;
+        });
+    };
+
     return (
         <Box height="100%" overflow="auto" paddingTop={1}>
             <Box display="flex" justifyContent="flex-end" marginBottom={1}>
@@ -159,6 +184,8 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan }) => {
                             const isUpdating = updatingTask === key;
                             const isBlocked = approval.status === 'NOT_STARTED' && approval.blockedBy.length > 0;
                             const status = statusDisplay(approval.status, isBlocked);
+                            const resourcePlan = resourcePlans.get(approval.resourceId);
+                            const changesExpanded = expandedChanges.has(key);
 
                             return (
                                 <Box key={key} border={1} borderColor="divider" borderRadius={1} padding={1.5}>
@@ -196,6 +223,53 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan }) => {
                                     {approval.description && (
                                         <Box mt={1}>
                                             <ReactMarkdown>{approval.description}</ReactMarkdown>
+                                        </Box>
+                                    )}
+                                    {resourcePlan && (
+                                        <Box mt={0.5}>
+                                            <Button
+                                                size="small"
+                                                variant="text"
+                                                endIcon={
+                                                    changesExpanded ? <KeyboardArrowUp /> : <KeyboardArrowDown />
+                                                }
+                                                aria-expanded={changesExpanded}
+                                                onClick={() => toggleChanges(key)}
+                                                sx={{ paddingLeft: 0, textTransform: 'none' }}
+                                            >
+                                                {changesExpanded ? 'Hide changes' : 'View changes'}
+                                            </Button>
+                                            <Collapse in={changesExpanded} timeout="auto" unmountOnExit>
+                                                <Box
+                                                    border={1}
+                                                    borderColor="divider"
+                                                    borderRadius={1}
+                                                    overflow="hidden"
+                                                    marginBottom={1}
+                                                >
+                                                    <Box padding={1} bgcolor="action.hover">
+                                                        <Typography variant="body2">
+                                                            <b>
+                                                                {resourcePlan.currentResource
+                                                                    ? 'Proposed resource changes'
+                                                                    : 'New resource'}
+                                                            </b>
+                                                        </Typography>
+                                                    </Box>
+                                                    <Box
+                                                        overflow="auto"
+                                                        sx={{
+                                                            '& table': { width: '100%' },
+                                                            '& pre': {
+                                                                whiteSpace: 'pre-wrap !important',
+                                                                overflowWrap: 'anywhere',
+                                                            },
+                                                        }}
+                                                    >
+                                                        <ResourceJsonDiff plan={resourcePlan} splitView={false} />
+                                                    </Box>
+                                                </Box>
+                                            </Collapse>
                                         </Box>
                                     )}
                                     {canAct && !isBlocked && (

--- a/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
@@ -7,9 +7,9 @@ import { ITask } from '../task/types';
 import { IExecutionPlan, TExecutionStatus } from './types';
 import { getExecutionApprovals } from './approvalUtils';
 import { ResourceJsonDiff } from './ExecPlanJsonDiff';
+import ApprovalReviewButton from './ApprovalReviewButton';
 
 const TASK_REFRESH_FREQUENCY = 5000;
-const APPROVAL_REVIEW_AGENT_ID = '019fde25-c4b0-747d-8e23-937e37c486da';
 
 interface IExecutionApprovalsProps {
     plan: Record<string, IExecutionPlan>;
@@ -52,7 +52,6 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan }) => {
         });
         return byResourceId;
     }, [plan]);
-    const reviewPrompt = `summarize : ${window.location.href}`;
     const blockedCount = approvals.filter(
         (approval) => approval.status === 'NOT_STARTED' && approval.blockedBy.length > 0
     ).length;
@@ -148,23 +147,7 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan }) => {
 
     return (
         <Box height="100%" overflow="auto" paddingTop={1}>
-            <Box display="flex" justifyContent="flex-end" marginBottom={1}>
-                <Button
-                    className="helix-ultra-button"
-                    data-agent-id={APPROVAL_REVIEW_AGENT_ID}
-                    data-button-name="Review with agent"
-                    data-pre-prompt={reviewPrompt}
-                    data-initial-placeholder-text="Ask about this Slate execution"
-                    data-create-new-chat="true"
-                    variant="outlined"
-                    color="primary"
-                    size="small"
-                    title="Open Helix Ultra to review this execution"
-                    sx={{ textTransform: 'none' }}
-                >
-                    Review with agent
-                </Button>
-            </Box>
+            <ApprovalReviewButton />
             {actionsUnavailable && (
                 <Alert severity="warning" sx={{ marginBottom: 1 }}>
                     Approval actions are temporarily unavailable.

--- a/core/src/main/resources/webapp/src/components/execution/NodeExecutionStatus.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/NodeExecutionStatus.tsx
@@ -1,25 +1,38 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Box, Typography, Tab } from '@mui/material';
 import { TabContext, TabList, TabPanel } from '@material-ui/lab';
-import { TTaskNode } from './types';
+import { IExecutionPlan, TTaskNode } from './types';
 import JsonPrettier from '../common/JsonPrettier';
+import ExecutionApprovals from './ExecutionApprovals';
 
 interface INodeExecutionStatusProps {
-    node: TTaskNode;
+    node: TTaskNode | null;
+    plan: Record<string, IExecutionPlan>;
 }
 
-const NodeExecutionStatus: React.FC<INodeExecutionStatusProps> = ({ node }) => {
-    const [selectedTab, setSelectedTab] = useState('1');
+const NodeExecutionStatus: React.FC<INodeExecutionStatusProps> = ({ node, plan }) => {
+    const [selectedTab, setSelectedTab] = useState('approvals');
 
-    const { data } = node;
-    if (!data) {
-        return null;
-    }
+    useEffect(() => {
+        if (node) {
+            setSelectedTab('task_status');
+        }
+    }, [node?.id]);
+
+    const data = node?.data;
     return (
         <Box justifyContent="center" flex="1" height="100%" width="100%">
             <Typography align="center" variant="subtitle1" style={{ background: '#f6f4f4' }}>
-                <b>{data.taskJson?.label}</b>
-                <span style={{ marginLeft: '2px', fontSize: '14px' }}>({data.taskJson?.task?.status})</span>
+                {data ? (
+                    <>
+                        <b>{data.taskJson?.label}</b>
+                        <span style={{ marginLeft: '2px', fontSize: '14px' }}>
+                            ({data.taskJson?.task?.status})
+                        </span>
+                    </>
+                ) : (
+                    <b>Execution approvals</b>
+                )}
             </Typography>
             <Box justifyContent="center" flex="1" height="100%" width="100%">
                 <TabContext value={selectedTab}>
@@ -28,25 +41,33 @@ const NodeExecutionStatus: React.FC<INodeExecutionStatusProps> = ({ node }) => {
                             setSelectedTab(newVal);
                         }}
                     >
-                        <Tab label="Task Status" value="1" />
-                        <Tab label="Process Context" value="2" />
+                        <Tab label="Approvals" value="approvals" />
+                        <Tab label="Task Status" value="task_status" disabled={!data} />
+                        <Tab label="Process Context" value="process_context" disabled={!data} />
                     </TabList>
-                    <TabPanel value="1" style={{ padding: '0px', height: '100%' }}>
-                        <Box maxHeight="25%" display="flex" flexDirection="column">
-                            <Typography style={{ paddingTop: '8px' }}>Standard Output</Typography>
-                            <JsonPrettier data={data.taskJson?.task?.stdOut} />
-                        </Box>
-                        <Box maxHeight="25%" display="flex" flexDirection="column">
-                            <Typography style={{ paddingTop: '8px' }}>Error</Typography>
-                            <JsonPrettier data={data.taskJson?.task?.stdErr} />
-                        </Box>
-                        <Box height="50%" display="flex" flexDirection="column">
-                            <Typography style={{ paddingTop: '8px' }}>Complete JSON</Typography>
-                            <JsonPrettier data={data.taskJson} />
-                        </Box>
+                    <TabPanel value="approvals" style={{ padding: '0px', height: 'calc(100% - 48px)' }}>
+                        <ExecutionApprovals plan={plan} />
+                    </TabPanel>
+                    <TabPanel value="task_status" style={{ padding: '0px', height: '100%' }}>
+                        {data && (
+                            <>
+                                <Box maxHeight="25%" display="flex" flexDirection="column">
+                                    <Typography style={{ paddingTop: '8px' }}>Standard Output</Typography>
+                                    <JsonPrettier data={data.taskJson?.task?.stdOut} />
+                                </Box>
+                                <Box maxHeight="25%" display="flex" flexDirection="column">
+                                    <Typography style={{ paddingTop: '8px' }}>Error</Typography>
+                                    <JsonPrettier data={data.taskJson?.task?.stdErr} />
+                                </Box>
+                                <Box height="50%" display="flex" flexDirection="column">
+                                    <Typography style={{ paddingTop: '8px' }}>Complete JSON</Typography>
+                                    <JsonPrettier data={data.taskJson} />
+                                </Box>
+                            </>
+                        )}
                     </TabPanel>
                     <TabPanel
-                        value="2"
+                        value="process_context"
                         style={{
                             padding: '0px',
                             paddingTop: '12px',
@@ -54,8 +75,8 @@ const NodeExecutionStatus: React.FC<INodeExecutionStatusProps> = ({ node }) => {
                             overflow: 'scroll',
                         }}
                     >
-                        {data.contextJson ? (
-                            <JsonPrettier data={data.contextJson as Object} />
+                        {data?.contextJson ? (
+                            <JsonPrettier data={data.contextJson as Record<string, unknown>} />
                         ) : (
                             <Typography mt={2} align="center" variant="subtitle1">
                                 No process context found

--- a/core/src/main/resources/webapp/src/components/execution/PlanGraph.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/PlanGraph.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box } from '@mui/material';
 import ReactFlow, { ReactFlowProvider, Background, NodeProps } from 'reactflow';
 import { IExecutionPlan, TTaskNode, ITaskNodeData, TTaskEdge } from './types';
 import NodeExecutionStatus from './NodeExecutionStatus';
@@ -17,7 +17,7 @@ interface IPlanGraphProps {
 
 const PlanGraph: React.FC<IPlanGraphProps> = ({ plan, width, height, dagWidth, showExecStatus = false }) => {
     const classes = useStyles();
-    const [selectedNode, setSelectedNode] = useState<null | TTaskNode>(null);
+    const [selectedNodeId, setSelectedNodeId] = useState<null | string>(null);
     const [rfNodes, setRFNodes] = useState<TTaskNode[]>([]);
     const [rfEdges, setRFEdges] = useState<TTaskEdge[]>([]);
 
@@ -25,8 +25,8 @@ const PlanGraph: React.FC<IPlanGraphProps> = ({ plan, width, height, dagWidth, s
         if (!plan) {
             return;
         }
-        let [nodes, edges] = buildGraphElementsFromPlan(plan);
-        nodes = organizeGraphElements(nodes, edges);
+        const [initialNodes, edges] = buildGraphElementsFromPlan(plan);
+        const nodes = organizeGraphElements(initialNodes, edges);
         setRFNodes(nodes ?? []);
         setRFEdges(edges ?? []);
     }, [plan]);
@@ -38,6 +38,11 @@ const PlanGraph: React.FC<IPlanGraphProps> = ({ plan, width, height, dagWidth, s
             },
         };
     }, []);
+
+    const selectedNode = useMemo(
+        () => rfNodes.find((node) => node.id === selectedNodeId) ?? null,
+        [rfNodes, selectedNodeId]
+    );
 
     return (
         <Box display="flex" flex="1" flexDirection="row" width={width} height={height}>
@@ -60,7 +65,7 @@ const PlanGraph: React.FC<IPlanGraphProps> = ({ plan, width, height, dagWidth, s
                             maxZoom={4}
                             onNodeClick={(e, node) => {
                                 if (showExecStatus) {
-                                    setSelectedNode(node);
+                                    setSelectedNodeId(node.id);
                                 }
                             }}
                         >
@@ -71,15 +76,7 @@ const PlanGraph: React.FC<IPlanGraphProps> = ({ plan, width, height, dagWidth, s
             </Box>
             {showExecStatus && (
                 <Box flex="1" paddingLeft={2} height="100%" width="100%" overflow="hidden">
-                    {selectedNode ? (
-                        <NodeExecutionStatus node={selectedNode} />
-                    ) : (
-                        <Box justifyContent="center" flex="1">
-                            <Typography align="center" variant="h6" component="h2">
-                                Select a node to view the task status
-                            </Typography>
-                        </Box>
-                    )}
+                    <NodeExecutionStatus node={selectedNode} plan={plan} />
                 </Box>
             )}
         </Box>

--- a/core/src/main/resources/webapp/src/components/execution/approvalUtils.ts
+++ b/core/src/main/resources/webapp/src/components/execution/approvalUtils.ts
@@ -2,46 +2,163 @@ import { IExecutionPlan, TExecutionStatus } from './types';
 
 export const GROUP_APPROVAL_TASK_DEFINITION_ID = 'groupApprovalTask';
 
+export interface IExecutionApprovalDependency {
+    id: string;
+    label: string;
+    status: TExecutionStatus;
+    type: 'resource' | 'task';
+}
+
 export interface IExecutionApproval {
     processId: string;
     taskId: string;
+    resourceId: string;
     group: string;
     summary: string;
     description: string;
     status: TExecutionStatus;
+    dependencyLevel: number;
+    blockedBy: IExecutionApprovalDependency[];
 }
 
 const readString = (value: unknown): string => (typeof value === 'string' ? value : '');
 
+const readRecord = (value: unknown): Record<string, unknown> =>
+    value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+
+const humanizeIdentifier = (value: string): string =>
+    value
+        .replace(/Definition$/, '')
+        .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+        .replace(/[_-]+/g, ' ')
+        .trim();
+
+const getResourceLabel = (resourceId: string, planEntry: IExecutionPlan): string => {
+    const resource = planEntry.proposedResource;
+    const desiredState = readRecord(resource?.desiredState);
+    const name =
+        readString(desiredState.name) ||
+        readString(desiredState.topicName) ||
+        readString(desiredState.logName) ||
+        readString(desiredState.filename);
+    const resourceType = humanizeIdentifier(resource?.resourceDefinitionClass?.split('.').pop() ?? '');
+
+    if (resourceType && name) {
+        return `${resourceType}: ${name}`;
+    }
+    return resourceType || name || resourceId;
+};
+
+const getCurrentTaskLabel = (planEntry: IExecutionPlan): string => {
+    const process = planEntry.process;
+    if (!process) {
+        return '';
+    }
+
+    for (const taskId of process.currenTaskSet ?? []) {
+        const context = readRecord(process.processContext?.[taskId]);
+        const summary = readString(context.summary);
+        if (summary) {
+            return summary;
+        }
+        if (process.allTasks[taskId]) {
+            return humanizeIdentifier(taskId);
+        }
+    }
+    return '';
+};
+
 export const getExecutionApprovals = (plan: Record<string, IExecutionPlan>): IExecutionApproval[] => {
     const approvals: IExecutionApproval[] = [];
+    const planByResourceId = new Map<string, IExecutionPlan>();
 
-    Object.values(plan).forEach(({ process }) => {
+    Object.entries(plan).forEach(([planId, planEntry]) => {
+        planByResourceId.set(planId, planEntry);
+        if (planEntry.proposedResource?.id) {
+            planByResourceId.set(planEntry.proposedResource.id, planEntry);
+        }
+    });
+
+    const dependencyLevel = (resourceId: string, visited: Set<string> = new Set()): number => {
+        if (visited.has(resourceId)) {
+            return 0;
+        }
+        const planEntry = planByResourceId.get(resourceId);
+        if (!planEntry) {
+            return 0;
+        }
+        const upstreamIds = (planEntry.upstreamVertices ?? []).filter(
+            (upstreamId): upstreamId is string =>
+                typeof upstreamId === 'string' && Boolean(planByResourceId.get(upstreamId)?.process)
+        );
+        if (!upstreamIds.length) {
+            return 0;
+        }
+
+        const nextVisited = new Set(visited);
+        nextVisited.add(resourceId);
+        return 1 + Math.max(...upstreamIds.map((upstreamId) => dependencyLevel(upstreamId, nextVisited)));
+    };
+
+    Object.entries(plan).forEach(([planId, planEntry]) => {
+        const { process } = planEntry;
         if (!process) {
             return;
         }
+        const resourceId = planEntry.proposedResource?.id || planId;
+        const blockedByResources: IExecutionApprovalDependency[] = [];
+        (planEntry.upstreamVertices ?? [])
+            .filter((upstreamId): upstreamId is string => typeof upstreamId === 'string')
+            .forEach((upstreamId) => {
+                const upstreamPlan = planByResourceId.get(upstreamId);
+                if (!upstreamPlan?.process || upstreamPlan.process.endStatus === 'SUCCEEDED') {
+                    return;
+                }
+                blockedByResources.push({
+                    id: upstreamId,
+                    label: getCurrentTaskLabel(upstreamPlan) || getResourceLabel(upstreamId, upstreamPlan),
+                    status: upstreamPlan.process.endStatus,
+                    type: 'resource',
+                });
+            });
 
         Object.entries(process.allTasks).forEach(([taskId, task]) => {
             if (task.taskDefinitionId !== GROUP_APPROVAL_TASK_DEFINITION_ID) {
                 return;
             }
 
-            const rawContext = process.processContext?.[taskId];
-            const context =
-                rawContext && typeof rawContext === 'object' && !Array.isArray(rawContext)
-                    ? (rawContext as Record<string, unknown>)
-                    : {};
+            const context = readRecord(process.processContext?.[taskId]);
+            const blockedBy = [...blockedByResources];
+            if (!blockedBy.length && task.status === 'NOT_STARTED' && process.endStatus === 'RUNNING') {
+                (process.currenTaskSet ?? [])
+                    .filter((currentTaskId) => currentTaskId !== taskId)
+                    .forEach((currentTaskId) => {
+                        const currentTask = process.allTasks[currentTaskId];
+                        if (currentTask && currentTask.status !== 'SUCCEEDED') {
+                            const currentContext = readRecord(process.processContext?.[currentTaskId]);
+                            blockedBy.push({
+                                id: currentTaskId,
+                                label: readString(currentContext.summary) || humanizeIdentifier(currentTaskId),
+                                status: currentTask.status,
+                                type: 'task',
+                            });
+                        }
+                    });
+            }
 
             approvals.push({
                 processId: process.processId,
                 taskId,
+                resourceId,
                 group: readString(context.approvalGroup),
                 summary: readString(context.summary) || taskId,
                 description: readString(context.description),
                 status: task.status,
+                dependencyLevel: dependencyLevel(resourceId),
+                blockedBy,
             });
         });
     });
 
-    return approvals;
+    return approvals.sort((left, right) => left.dependencyLevel - right.dependencyLevel);
 };

--- a/core/src/main/resources/webapp/src/components/execution/approvalUtils.ts
+++ b/core/src/main/resources/webapp/src/components/execution/approvalUtils.ts
@@ -1,0 +1,47 @@
+import { IExecutionPlan, TExecutionStatus } from './types';
+
+export const GROUP_APPROVAL_TASK_DEFINITION_ID = 'groupApprovalTask';
+
+export interface IExecutionApproval {
+    processId: string;
+    taskId: string;
+    group: string;
+    summary: string;
+    description: string;
+    status: TExecutionStatus;
+}
+
+const readString = (value: unknown): string => (typeof value === 'string' ? value : '');
+
+export const getExecutionApprovals = (plan: Record<string, IExecutionPlan>): IExecutionApproval[] => {
+    const approvals: IExecutionApproval[] = [];
+
+    Object.values(plan).forEach(({ process }) => {
+        if (!process) {
+            return;
+        }
+
+        Object.entries(process.allTasks).forEach(([taskId, task]) => {
+            if (task.taskDefinitionId !== GROUP_APPROVAL_TASK_DEFINITION_ID) {
+                return;
+            }
+
+            const rawContext = process.processContext?.[taskId];
+            const context =
+                rawContext && typeof rawContext === 'object' && !Array.isArray(rawContext)
+                    ? (rawContext as Record<string, unknown>)
+                    : {};
+
+            approvals.push({
+                processId: process.processId,
+                taskId,
+                group: readString(context.approvalGroup),
+                summary: readString(context.summary) || taskId,
+                description: readString(context.description),
+                status: task.status,
+            });
+        });
+    });
+
+    return approvals;
+};


### PR DESCRIPTION
## Summary

This PR centralizes execution approvals in a dedicated tab where all viewers can inspect statuses, dependency ordering, blockers, and associated resource changes without navigating between views. Approve and Deny controls remain permission-gated through the existing task API, while compact status cues keep chained approvals understandable in the narrow execution panel. 

### Problem (Why)

Execution approvals were split across the plan graph, task status, task list, and resource-change views. Reviewers had to find each approval separately, leave the approval context to inspect the referenced resource diff, and infer why downstream approvals were not yet actionable.

### Solution (What + How)

- Add an Approvals tab before Task Status in execution details so every reviewer can see all required approvals in one place.
- Gate Approve and Deny actions using the existing group-task API while keeping approval metadata visible to users without action permissions.
- Order approvals by dependency stage and show direct blockers with distinct status colors, keeping deep dependency chains readable in the narrow detail panel.
- Add a collapsed, single-column resource diff to each approval card by reusing the Resource Changes renderer.
- Keep selected task details synchronized with graph polling by storing the selected node ID rather than a stale node snapshot.

Unapproved topic gates the two dependent approvals
<img width="1856" height="973" alt="Screenshot 2026-08-07 at 6 13 50 PM" src="https://github.com/user-attachments/assets/0a944a5a-cbf1-4212-ad18-6a211b5d5222" />

Approving the topic allows for the second layer of approvals
<img width="1857" height="972" alt="Screenshot 2026-08-07 at 6 13 58 PM" src="https://github.com/user-attachments/assets/1e1c2fad-a26e-46d9-9abc-f6d2354b3c7e" />


Inline resource changes
<img width="1860" height="973" alt="Screenshot 2026-08-07 at 6 14 07 PM" src="https://github.com/user-attachments/assets/9f1685d7-b4a2-49f8-be8e-bcc853cd3be5" />


With agent-id set in backend -- `review with agent` button shown
<img width="1859" height="973" alt="Screenshot 2026-08-07 at 6 23 38 PM" src="https://github.com/user-attachments/assets/015e4e2a-90b7-407d-b311-0d21a7dd172a" />


Without agent-id set in backend -- `review with agent` hidden
<img width="1860" height="971" alt="Screenshot 2026-08-07 at 6 14 41 PM" src="https://github.com/user-attachments/assets/954a6a96-d8c6-4694-8a83-f6dc6a660cdf" />


## Test Plan

- `npx tsc --noEmit`
- `npx eslint src/components/execution/ExecPlanJsonDiff.tsx src/components/execution/ExecutionApprovals.tsx src/components/execution/NodeExecutionStatus.tsx src/components/execution/PlanGraph.tsx src/components/execution/approvalUtils.ts`
- Focused local approval utility tests covering extraction, malformed context, dependency ordering, direct blockers, and deep chains.
