### PR TITLE
Improve execution approvals UX: timestamps, focus-on-hover, consolidated details, review button polish

### DIFF
--- a/core/src/main/resources/webapp/src/components/common/JsonPrettier.tsx
+++ b/core/src/main/resources/webapp/src/components/common/JsonPrettier.tsx
@@ -30,13 +30,13 @@ const escapeHtml = (value: string): string =>
 // which react-json-pretty's line-based tokenizer cannot). Based on the classic
 // MDN JSON.stringify + span-wrapping approach.
 const highlightJson = (data: unknown): string => {
-    let json: string;
+    let json: string | undefined;
     try {
         json = JSON.stringify(data, null, 2);
     } catch {
-        return escapeHtml(String(data));
+        json = undefined;
     }
-    if (json === undefined) {
+    if (typeof json !== 'string') {
         return escapeHtml(String(data));
     }
     return escapeHtml(json).replace(

--- a/core/src/main/resources/webapp/src/components/common/JsonPrettier.tsx
+++ b/core/src/main/resources/webapp/src/components/common/JsonPrettier.tsx
@@ -12,28 +12,63 @@ interface IJsonPrettierProps {
     height?: string;
     width?: string;
     stringStyle?: string;
+    variant?: 'dark' | 'light';
 }
 
-const JsonPrettier: React.FC<IJsonPrettierProps> = (data, height = '100%', width = '100%', stringStyle = undefined) => {
+const lightTheme = {
+    main: 'line-height:1.4;color:#37474f;background:#fafafa;overflow:auto;',
+    error: 'line-height:1.4;color:#37474f;background:#fafafa;overflow:auto;',
+    key: 'color:#0d47a1;',
+    string: 'color:#2e7d32;',
+    value: 'color:#b45309;',
+    boolean: 'color:#7b1fa2;',
+};
+
+const JsonPrettier: React.FC<IJsonPrettierProps> = ({
+    data,
+    height,
+    width = '100%',
+    stringStyle,
+    variant = 'dark',
+}: IJsonPrettierProps) => {
     const classes = useStyles();
+    const isLight = variant === 'light';
+    const resolvedHeight = height ?? (isLight ? 'auto' : '100%');
     return (
-        <Box height={height} style={{ height: height, width: width, overflow: 'scroll', position: 'relative' }}>
+        <Box
+            height={resolvedHeight}
+            style={{
+                height: resolvedHeight,
+                width: width,
+                overflow: isLight ? 'visible' : 'auto',
+                position: 'relative',
+                border: isLight ? '1px solid #e0e0e0' : undefined,
+                borderRadius: isLight ? '4px' : undefined,
+            }}
+        >
             <Tooltip title="Copy JSON" placement="top" arrow>
                 <IconButton
-                    style={{ padding: '0', paddingLeft: '4px', position: 'absolute', top: '12px', right: '12px' }}
+                    style={{
+                        padding: '0',
+                        paddingLeft: '4px',
+                        position: 'absolute',
+                        top: '12px',
+                        right: '12px',
+                        color: isLight ? '#546e7a' : undefined,
+                    }}
                     color="info"
                     component="span"
                     onClick={() => {
-                        navigator.clipboard.writeText(JSON.stringify(data.data?data.data:data));
+                        navigator.clipboard.writeText(JSON.stringify(data));
                     }}
                 >
                     <ContentCopy fontSize="small" />
                 </IconButton>
             </Tooltip>
             <JSONPretty
-                style={{ overflow: 'scroll', padding: '0px' }}
-                data={data.data?data.data:data}
-                theme={JSONPrettyMon}
+                style={{ overflow: isLight ? 'visible' : 'auto', padding: '0px' }}
+                data={data}
+                theme={isLight ? lightTheme : JSONPrettyMon}
                 mainStyle="margin:0"
                 stringStyle={stringStyle}
             />

--- a/core/src/main/resources/webapp/src/components/common/JsonPrettier.tsx
+++ b/core/src/main/resources/webapp/src/components/common/JsonPrettier.tsx
@@ -15,13 +15,44 @@ interface IJsonPrettierProps {
     variant?: 'dark' | 'light';
 }
 
-const lightTheme = {
-    main: 'line-height:1.4;color:#37474f;background:#fafafa;overflow:auto;',
-    error: 'line-height:1.4;color:#37474f;background:#fafafa;overflow:auto;',
-    key: 'color:#0d47a1;',
-    string: 'color:#2e7d32;',
-    value: 'color:#b45309;',
-    boolean: 'color:#7b1fa2;',
+const LIGHT_COLORS = {
+    key: '#0d47a1',
+    string: '#2e7d32',
+    number: '#b45309',
+    boolean: '#7b1fa2',
+    null: '#78909c',
+};
+
+const escapeHtml = (value: string): string =>
+    value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+// Robust JSON syntax highlighter (handles strings with embedded escaped quotes,
+// which react-json-pretty's line-based tokenizer cannot). Based on the classic
+// MDN JSON.stringify + span-wrapping approach.
+const highlightJson = (data: unknown): string => {
+    let json: string;
+    try {
+        json = JSON.stringify(data, null, 2);
+    } catch {
+        return escapeHtml(String(data));
+    }
+    if (json === undefined) {
+        return escapeHtml(String(data));
+    }
+    return escapeHtml(json).replace(
+        /("(\\u[a-fA-F0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?)/g,
+        (match) => {
+            let color: string = LIGHT_COLORS.number;
+            if (match[0] === '"') {
+                color = /:\s*$/.test(match) ? LIGHT_COLORS.key : LIGHT_COLORS.string;
+            } else if (match === 'true' || match === 'false') {
+                color = LIGHT_COLORS.boolean;
+            } else if (match === 'null') {
+                color = LIGHT_COLORS.null;
+            }
+            return `<span style="color:${color}">${match}</span>`;
+        }
+    );
 };
 
 const JsonPrettier: React.FC<IJsonPrettierProps> = ({
@@ -65,13 +96,32 @@ const JsonPrettier: React.FC<IJsonPrettierProps> = ({
                     <ContentCopy fontSize="small" />
                 </IconButton>
             </Tooltip>
-            <JSONPretty
-                style={{ overflow: isLight ? 'visible' : 'auto', padding: '0px' }}
-                data={data}
-                theme={isLight ? lightTheme : JSONPrettyMon}
-                mainStyle="margin:0"
-                stringStyle={stringStyle}
-            />
+            {isLight ? (
+                <pre
+                    style={{
+                        margin: 0,
+                        padding: '8px 32px 8px 8px',
+                        lineHeight: 1.4,
+                        color: '#37474f',
+                        background: '#fafafa',
+                        whiteSpace: 'pre-wrap',
+                        overflowWrap: 'anywhere',
+                        wordBreak: 'break-word',
+                        fontFamily:
+                            'ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace',
+                        fontSize: '13px',
+                    }}
+                    dangerouslySetInnerHTML={{ __html: highlightJson(data) }}
+                />
+            ) : (
+                <JSONPretty
+                    style={{ overflow: 'auto', padding: '0px' }}
+                    data={data}
+                    theme={JSONPrettyMon}
+                    mainStyle="margin:0"
+                    stringStyle={stringStyle}
+                />
+            )}
         </Box>
     );
 };

--- a/core/src/main/resources/webapp/src/components/execution/ApprovalReviewButton.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/ApprovalReviewButton.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Button } from '@mui/material';
+import { Button } from '@mui/material';
 
 type ApprovalReviewButtonConfig = Record<string, string>;
 
@@ -57,25 +57,29 @@ const ApprovalReviewButton: React.FC<IApprovalReviewButtonProps> = ({ executionU
         .join(' ');
 
     return (
-        <Box display="flex" justifyContent="flex-end" marginBottom={1}>
-            <Button
-                className={safeClassName}
-                {...safeAttributes}
-                aria-label={safeAttributes['aria-label'] ?? label}
-                title={title}
-                variant="contained"
-                color="primary"
-                size="small"
-                sx={{ textTransform: 'none' }}
-            >
-                {icon && (
-                    <span aria-hidden="true" style={{ marginRight: 8 }}>
-                        {icon}
-                    </span>
-                )}
-                {label}
-            </Button>
-        </Box>
+        <Button
+            className={safeClassName}
+            {...safeAttributes}
+            aria-label={safeAttributes['aria-label'] ?? label}
+            title={title}
+            variant="contained"
+            size="small"
+            sx={{
+                textTransform: 'none',
+                flexShrink: 0,
+                backgroundColor: '#ed6c02',
+                '&:hover': {
+                    backgroundColor: '#c55a02',
+                },
+            }}
+        >
+            {icon && (
+                <span aria-hidden="true" style={{ marginRight: 8 }}>
+                    {icon}
+                </span>
+            )}
+            {label}
+        </Button>
     );
 };
 

--- a/core/src/main/resources/webapp/src/components/execution/ApprovalReviewButton.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/ApprovalReviewButton.tsx
@@ -7,7 +7,11 @@ const SAFE_ATTRIBUTE_PATTERN = /^(data|aria)-[a-z0-9_.:-]+$/;
 const SAFE_CLASS_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
 const URL_PLACEHOLDER = '{url}';
 
-const ApprovalReviewButton: React.FC = () => {
+interface IApprovalReviewButtonProps {
+    executionUrl?: string;
+}
+
+const ApprovalReviewButton: React.FC<IApprovalReviewButtonProps> = ({ executionUrl }) => {
     const [config, setConfig] = useState<ApprovalReviewButtonConfig>({});
 
     useEffect(() => {
@@ -35,15 +39,15 @@ const ApprovalReviewButton: React.FC = () => {
         };
     }, []);
 
-    const { label, title, className = '', ...attributes } = config;
+    const { label, icon, title, className = '', ...attributes } = config;
     if (!label) {
         return null;
     }
 
+    const url = executionUrl || window.location.href;
     const safeAttributes = Object.entries(attributes).reduce<Record<string, string>>((result, [name, value]) => {
         if (SAFE_ATTRIBUTE_PATTERN.test(name) && typeof value === 'string') {
-            result[name] =
-                name === 'data-pre-prompt' ? value.split(URL_PLACEHOLDER).join(window.location.href) : value;
+            result[name] = name === 'data-pre-prompt' ? value.split(URL_PLACEHOLDER).join(url) : value;
         }
         return result;
     }, {});
@@ -59,11 +63,16 @@ const ApprovalReviewButton: React.FC = () => {
                 {...safeAttributes}
                 aria-label={safeAttributes['aria-label'] ?? label}
                 title={title}
-                variant="outlined"
+                variant="contained"
                 color="primary"
                 size="small"
                 sx={{ textTransform: 'none' }}
             >
+                {icon && (
+                    <span aria-hidden="true" style={{ marginRight: 8 }}>
+                        {icon}
+                    </span>
+                )}
                 {label}
             </Button>
         </Box>

--- a/core/src/main/resources/webapp/src/components/execution/ApprovalReviewButton.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/ApprovalReviewButton.tsx
@@ -63,15 +63,9 @@ const ApprovalReviewButton: React.FC<IApprovalReviewButtonProps> = ({ executionU
             aria-label={safeAttributes['aria-label'] ?? label}
             title={title}
             variant="contained"
+            color="secondary"
             size="small"
-            sx={{
-                textTransform: 'none',
-                flexShrink: 0,
-                backgroundColor: '#ed6c02',
-                '&:hover': {
-                    backgroundColor: '#c55a02',
-                },
-            }}
+            sx={{ textTransform: 'none', flexShrink: 0 }}
         >
             {icon && (
                 <span aria-hidden="true" style={{ marginRight: 8 }}>

--- a/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
@@ -208,7 +208,13 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
     };
 
     return (
-        <Box height="100%" overflow="auto" paddingTop={1}>
+        <Box
+            height="100%"
+            overflow="auto"
+            paddingTop={1}
+            paddingRight={2}
+            sx={{ scrollbarGutter: 'stable' }}
+        >
             {actionsUnavailable && (
                 <Alert severity="warning" sx={{ marginBottom: 1 }}>
                     Approval actions are temporarily unavailable.

--- a/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
@@ -496,8 +496,8 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
                                     <Typography variant="body2" marginBottom={0.5}>
                                         <b>Standard output</b>
                                     </Typography>
-                                    <Box maxHeight="30vh" marginBottom={1.5} minWidth={0} overflow="auto">
-                                        <JsonPrettier data={selectedContext.json.stdOut} />
+                                    <Box marginBottom={1.5} minWidth={0}>
+                                        <JsonPrettier data={selectedContext.json.stdOut} variant="light" />
                                     </Box>
                                 </>
                             )}
@@ -506,8 +506,8 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
                                     <Typography variant="body2" marginBottom={0.5}>
                                         <b>Standard error</b>
                                     </Typography>
-                                    <Box maxHeight="30vh" marginBottom={1.5} minWidth={0} overflow="auto">
-                                        <JsonPrettier data={selectedContext.json.stdErr} />
+                                    <Box marginBottom={1.5} minWidth={0}>
+                                        <JsonPrettier data={selectedContext.json.stdErr} variant="light" />
                                     </Box>
                                 </>
                             )}
@@ -516,16 +516,16 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
                                     <Typography variant="body2" marginBottom={0.5}>
                                         <b>Process context</b>
                                     </Typography>
-                                    <Box maxHeight="30vh" marginBottom={1.5} minWidth={0} overflow="auto">
-                                        <JsonPrettier data={selectedContext.context} />
+                                    <Box marginBottom={1.5} minWidth={0}>
+                                        <JsonPrettier data={selectedContext.context} variant="light" />
                                     </Box>
                                 </>
                             )}
                             <Typography variant="body2" marginBottom={0.5}>
                                 <b>Complete task JSON</b>
                             </Typography>
-                            <Box maxHeight="30vh" minWidth={0} overflow="auto">
-                                <JsonPrettier data={selectedContext.json} />
+                            <Box minWidth={0}>
+                                <JsonPrettier data={selectedContext.json} variant="light" />
                             </Box>
                         </Box>
                     ) : (

--- a/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
     Alert,
     alpha,
@@ -18,58 +18,20 @@ import { KeyboardArrowDown, KeyboardArrowUp } from '@mui/icons-material';
 import ReactMarkdown from 'react-markdown';
 import { useSnackBar } from '../../context/SnackbarContext';
 import { ITask } from '../task/types';
-import { IExecutionPlan, TExecutionStatus } from './types';
-import { getExecutionApprovals } from './approvalUtils';
+import { IExecutionPlan, IExecutionTaskJson, TExecutionStatus } from './types';
+import { formatApprovalDate, formatApprovalWait, getExecutionApprovals } from './approvalUtils';
 import { ResourceJsonDiff } from './ExecPlanJsonDiff';
 import ApprovalReviewButton from './ApprovalReviewButton';
+import JsonPrettier from '../common/JsonPrettier';
 
 const TASK_REFRESH_FREQUENCY = 5000;
-const DESCRIPTION_PREVIEW_LENGTH = 240;
 
 interface IExecutionApprovalsProps {
     plan: Record<string, IExecutionPlan>;
+    focusedApprovalKey?: string | null;
 }
 
 const taskKey = (processId: string, taskId: string): string => `${processId}:${taskId}`;
-
-interface IDescriptionPreview {
-    text: string;
-    hasHiddenContext: boolean;
-}
-
-const truncateDescription = (description: string): string => {
-    const preview = description.slice(0, DESCRIPTION_PREVIEW_LENGTH);
-    const lastWhitespace = preview.lastIndexOf(' ');
-    const cutoff = lastWhitespace > DESCRIPTION_PREVIEW_LENGTH / 2 ? lastWhitespace : preview.length;
-    return `${preview.slice(0, cutoff).replace(/\s+$/, '')}…`;
-};
-
-const getDescriptionPreview = (description: string): IDescriptionPreview => {
-    const trimmed = description.trim();
-    const isStructuredOnly = /^(?:json\s*:|\{|\[)/i.test(trimmed);
-    if (isStructuredOnly) {
-        return { text: '', hasHiddenContext: true };
-    }
-
-    const structuredContextIndexes = [
-        description.search(/(?:^|\n)\s*(?:task\s+)?json\s*:/i),
-        description.search(/(?:^|\n)\s*```(?:json)?/i),
-    ].filter((index) => index >= 0);
-    const structuredContextStart = structuredContextIndexes.length ? Math.min(...structuredContextIndexes) : -1;
-    const prose = structuredContextStart >= 0 ? description.slice(0, structuredContextStart) : description;
-    const plainText = prose
-        .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-        .replace(/[*_`#>]/g, '')
-        .replace(/\s+-\s+/g, ' · ')
-        .replace(/\s+/g, ' ')
-        .trim();
-    const isTruncated = plainText.length > DESCRIPTION_PREVIEW_LENGTH;
-
-    return {
-        text: isTruncated ? truncateDescription(plainText) : plainText,
-        hasHiddenContext: structuredContextStart >= 0 || isTruncated,
-    };
-};
 
 const statusDisplay = (
     status: TExecutionStatus,
@@ -92,10 +54,27 @@ const statusDisplay = (
     }
 };
 
-const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan }) => {
+type TApprovalDialog =
+    | { kind: 'description'; summary: string; description: string }
+    | { kind: 'json'; summary: string; json: IExecutionTaskJson };
+
+const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedApprovalKey }) => {
     const { showSnackbar } = useSnackBar();
     const theme = useTheme();
     const approvals = useMemo(() => getExecutionApprovals(plan), [plan]);
+    const taskJsonByKey = useMemo(() => {
+        const byKey = new Map<string, IExecutionTaskJson>();
+        Object.values(plan).forEach((planEntry) => {
+            const process = planEntry.process;
+            if (!process) {
+                return;
+            }
+            Object.entries(process.allTasks).forEach(([taskId, task]) => {
+                byKey.set(taskKey(process.processId, taskId), task);
+            });
+        });
+        return byKey;
+    }, [plan]);
     const resourcePlans = useMemo(() => {
         const byResourceId = new Map<string, IExecutionPlan>();
         Object.entries(plan).forEach(([planId, planEntry]) => {
@@ -117,7 +96,14 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan }) => {
     const [actionsUnavailable, setActionsUnavailable] = useState(false);
     const [updatingTask, setUpdatingTask] = useState<null | string>(null);
     const [expandedChanges, setExpandedChanges] = useState<Set<string>>(new Set());
-    const [selectedContext, setSelectedContext] = useState<null | { description: string; summary: string }>(null);
+    const [selectedContext, setSelectedContext] = useState<null | TApprovalDialog>(null);
+    const focusedCardRef = useRef<null | HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (focusedApprovalKey && focusedCardRef.current) {
+            focusedCardRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        }
+    }, [focusedApprovalKey]);
 
     const fetchActionableTasks = useCallback(() => {
         fetch('/api/v2/tasks/mygrouptasks', {
@@ -226,13 +212,20 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan }) => {
                             const status = statusDisplay(approval.status, isBlocked);
                             const resourcePlan = resourcePlans.get(approval.resourceId);
                             const changesExpanded = expandedChanges.has(key);
-                            const description = getDescriptionPreview(approval.description);
+                            const isAwaiting = approval.status === 'RUNNING' && !isBlocked;
+                            const waitingLabel = isAwaiting ? formatApprovalWait(approval.startTimeMs, Date.now()) : '';
+                            const approvedDate =
+                                approval.status === 'SUCCEEDED' ? formatApprovalDate(approval.endTimeMs) : '';
+                            const isFocused = focusedApprovalKey === key;
+                            const taskJson = taskJsonByKey.get(key);
 
                             return (
                                 <Box
                                     key={key}
+                                    ref={isFocused ? focusedCardRef : undefined}
                                     border={1}
-                                    borderColor="divider"
+                                    borderColor={isFocused ? 'primary.main' : 'divider'}
+                                    bgcolor={isFocused ? alpha(theme.palette.primary.main, 0.06) : undefined}
                                     borderRadius={1}
                                     padding={1.5}
                                     minWidth={0}
@@ -244,16 +237,34 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan }) => {
                                                 <b>{approval.summary}</b>
                                             </Typography>
                                             <Typography variant="body2" color="text.secondary">
-                                                Stage {approval.dependencyLevel + 1} · Approval group:{' '}
-                                                {approval.group || 'Unknown'}
+                                                Stage {approval.dependencyLevel + 1}
+                                            </Typography>
+                                            <Typography variant="body2">
+                                                Approval group: <b>{approval.group || 'Unknown'}</b>
                                             </Typography>
                                         </Box>
-                                        <Chip
-                                            size="small"
-                                            label={status.label}
-                                            color={status.color}
-                                            sx={{ flexShrink: 0 }}
-                                        />
+                                        <Stack alignItems="flex-end" spacing={0.5} sx={{ flexShrink: 0 }}>
+                                            <Chip size="small" label={status.label} color={status.color} />
+                                            {waitingLabel ? (
+                                                <Typography
+                                                    variant="caption"
+                                                    color="text.secondary"
+                                                    textAlign="right"
+                                                >
+                                                    {waitingLabel}
+                                                </Typography>
+                                            ) : (
+                                                approvedDate && (
+                                                    <Typography
+                                                        variant="caption"
+                                                        color="text.secondary"
+                                                        textAlign="right"
+                                                    >
+                                                        Approved {approvedDate}
+                                                    </Typography>
+                                                )
+                                            )}
+                                        </Stack>
                                     </Stack>
                                     {isBlocked && (
                                         <Box
@@ -274,30 +285,15 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan }) => {
                                             )}
                                         </Box>
                                     )}
-                                    {description.text && (
-                                        <Typography
-                                            variant="body2"
-                                            mt={1}
-                                            sx={{
-                                                display: '-webkit-box',
-                                                WebkitBoxOrient: 'vertical',
-                                                WebkitLineClamp: 2,
-                                                overflow: 'hidden',
-                                                overflowWrap: 'anywhere',
-                                                wordBreak: 'break-word',
-                                            }}
-                                        >
-                                            {description.text}
-                                        </Typography>
-                                    )}
-                                    {(description.hasHiddenContext || resourcePlan) && (
+                                    {(approval.description || taskJson || resourcePlan) && (
                                         <Box display="flex" flexWrap="wrap" alignItems="center" gap={1} mt={0.5}>
-                                            {description.hasHiddenContext && (
+                                            {approval.description && (
                                                 <Button
                                                     size="small"
                                                     variant="text"
                                                     onClick={() =>
                                                         setSelectedContext({
+                                                            kind: 'description',
                                                             description: approval.description,
                                                             summary: approval.summary,
                                                         })
@@ -305,6 +301,22 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan }) => {
                                                     sx={{ paddingLeft: 0, textTransform: 'none' }}
                                                 >
                                                     View full description
+                                                </Button>
+                                            )}
+                                            {taskJson && (
+                                                <Button
+                                                    size="small"
+                                                    variant="text"
+                                                    onClick={() =>
+                                                        setSelectedContext({
+                                                            kind: 'json',
+                                                            json: taskJson,
+                                                            summary: approval.summary,
+                                                        })
+                                                    }
+                                                    sx={{ paddingLeft: 0, textTransform: 'none' }}
+                                                >
+                                                    View complete JSON
                                                 </Button>
                                             )}
                                             {resourcePlan && (
@@ -395,7 +407,7 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan }) => {
                 maxWidth="md"
             >
                 <DialogTitle>
-                    Approval description
+                    {selectedContext?.kind === 'json' ? 'Approval task JSON' : 'Approval description'}
                     {selectedContext && (
                         <Typography variant="body2" color="text.secondary">
                             {selectedContext.summary}
@@ -417,7 +429,13 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan }) => {
                         },
                     }}
                 >
-                    {selectedContext && <ReactMarkdown>{selectedContext.description}</ReactMarkdown>}
+                    {selectedContext?.kind === 'json' ? (
+                        <Box height="60vh" minWidth={0}>
+                            <JsonPrettier data={selectedContext.json} />
+                        </Box>
+                    ) : (
+                        selectedContext && <ReactMarkdown>{selectedContext.description}</ReactMarkdown>
+                    )}
                 </DialogContent>
                 <DialogActions>
                     <Button onClick={() => setSelectedContext(null)}>Close</Button>

--- a/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
@@ -19,7 +19,13 @@ import ReactMarkdown from 'react-markdown';
 import { useSnackBar } from '../../context/SnackbarContext';
 import { ITask } from '../task/types';
 import { IExecutionPlan, IExecutionTaskJson, TExecutionStatus } from './types';
-import { formatApprovalDate, formatApprovalWait, getExecutionApprovals } from './approvalUtils';
+import {
+    formatApprovalDate,
+    formatApprovalSummary,
+    formatApprovalSummaryParts,
+    formatApprovalWait,
+    getExecutionApprovals,
+} from './approvalUtils';
 import { ResourceJsonDiff } from './ExecPlanJsonDiff';
 import ApprovalReviewButton from './ApprovalReviewButton';
 import JsonPrettier from '../common/JsonPrettier';
@@ -54,26 +60,44 @@ const statusDisplay = (
     }
 };
 
+interface IApprovalTaskDetails {
+    task: IExecutionTaskJson;
+    context: null | Record<string, unknown>;
+}
+
 type TApprovalDialog =
     | { kind: 'description'; summary: string; description: string }
-    | { kind: 'json'; summary: string; json: IExecutionTaskJson };
+    | {
+          kind: 'advanced';
+          summary: string;
+          rawSummary: string;
+          json: IExecutionTaskJson;
+          context: null | Record<string, unknown>;
+      };
 
 const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedApprovalKey }) => {
     const { showSnackbar } = useSnackBar();
     const theme = useTheme();
     const approvals = useMemo(() => getExecutionApprovals(plan), [plan]);
     const taskJsonByKey = useMemo(() => {
-        const byKey = new Map<string, IExecutionTaskJson>();
+        const byKey = new Map<string, IApprovalTaskDetails>();
         Object.values(plan).forEach((planEntry) => {
             const process = planEntry.process;
             if (!process) {
                 return;
             }
             Object.entries(process.allTasks).forEach(([taskId, task]) => {
-                byKey.set(taskKey(process.processId, taskId), task);
+                byKey.set(taskKey(process.processId, taskId), {
+                    task,
+                    context: process.processContext?.[taskId] ?? null,
+                });
             });
         });
         return byKey;
+    }, [plan]);
+    const executionUrl = useMemo(() => {
+        const executionId = Object.values(plan).find((planEntry) => planEntry.process)?.process?.executionId;
+        return executionId ? `${window.location.origin}/executions/${executionId}` : undefined;
     }, [plan]);
     const resourcePlans = useMemo(() => {
         const byResourceId = new Map<string, IExecutionPlan>();
@@ -188,7 +212,7 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
 
     return (
         <Box height="100%" overflow="auto" paddingTop={1}>
-            <ApprovalReviewButton />
+            <ApprovalReviewButton executionUrl={executionUrl} />
             {actionsUnavailable && (
                 <Alert severity="warning" sx={{ marginBottom: 1 }}>
                     Approval actions are temporarily unavailable.
@@ -217,7 +241,10 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
                             const approvedDate =
                                 approval.status === 'SUCCEEDED' ? formatApprovalDate(approval.endTimeMs) : '';
                             const isFocused = focusedApprovalKey === key;
-                            const taskJson = taskJsonByKey.get(key);
+                            const taskDetails = taskJsonByKey.get(key);
+                            const taskJson = taskDetails?.task;
+                            const displaySummary = formatApprovalSummary(approval.summary);
+                            const summaryParts = formatApprovalSummaryParts(approval.summary);
 
                             return (
                                 <Box
@@ -233,11 +260,24 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
                                 >
                                     <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing={1}>
                                         <Box minWidth={0}>
-                                            <Typography variant="subtitle1" sx={{ overflowWrap: 'anywhere' }}>
-                                                <b>{approval.summary}</b>
-                                            </Typography>
-                                            <Typography variant="body2" color="text.secondary">
-                                                Stage {approval.dependencyLevel + 1}
+                                            <Typography
+                                                variant="subtitle1"
+                                                title={approval.summary}
+                                                sx={{ overflowWrap: 'anywhere' }}
+                                            >
+                                                {summaryParts.prefix}
+                                                {summaryParts.name && (
+                                                    <>
+                                                        {' '}
+                                                        <b>{summaryParts.name}</b>
+                                                    </>
+                                                )}
+                                                {summaryParts.cluster && (
+                                                    <>
+                                                        {' '}
+                                                        in <b>{summaryParts.cluster}</b>
+                                                    </>
+                                                )}
                                             </Typography>
                                             <Typography variant="body2">
                                                 Approval group: <b>{approval.group || 'Unknown'}</b>
@@ -274,8 +314,12 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
                                             borderLeft={2}
                                             borderColor="warning.main"
                                         >
-                                            <Typography variant="body2" sx={{ overflowWrap: 'anywhere' }}>
-                                                <b>Waiting for:</b> {approval.blockedBy[0].label}
+                                            <Typography
+                                                variant="body2"
+                                                title={approval.blockedBy[0].label}
+                                                sx={{ overflowWrap: 'anywhere' }}
+                                            >
+                                                <b>Waiting for:</b> {formatApprovalSummary(approval.blockedBy[0].label)}
                                             </Typography>
                                             {approval.blockedBy.length > 1 && (
                                                 <Typography variant="caption" color="text.secondary">
@@ -295,12 +339,12 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
                                                         setSelectedContext({
                                                             kind: 'description',
                                                             description: approval.description,
-                                                            summary: approval.summary,
+                                                            summary: displaySummary,
                                                         })
                                                     }
                                                     sx={{ paddingLeft: 0, textTransform: 'none' }}
                                                 >
-                                                    View full description
+                                                    View description
                                                 </Button>
                                             )}
                                             {taskJson && (
@@ -309,14 +353,16 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
                                                     variant="text"
                                                     onClick={() =>
                                                         setSelectedContext({
-                                                            kind: 'json',
+                                                            kind: 'advanced',
                                                             json: taskJson,
-                                                            summary: approval.summary,
+                                                            context: taskDetails?.context ?? null,
+                                                            summary: displaySummary,
+                                                            rawSummary: approval.summary,
                                                         })
                                                     }
                                                     sx={{ paddingLeft: 0, textTransform: 'none' }}
                                                 >
-                                                    View complete JSON
+                                                    View advanced
                                                 </Button>
                                             )}
                                             {resourcePlan && (
@@ -407,7 +453,7 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
                 maxWidth="md"
             >
                 <DialogTitle>
-                    {selectedContext?.kind === 'json' ? 'Approval task JSON' : 'Approval description'}
+                    {selectedContext?.kind === 'advanced' ? 'Approval details' : 'Approval description'}
                     {selectedContext && (
                         <Typography variant="body2" color="text.secondary">
                             {selectedContext.summary}
@@ -429,9 +475,58 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
                         },
                     }}
                 >
-                    {selectedContext?.kind === 'json' ? (
-                        <Box height="60vh" minWidth={0}>
-                            <JsonPrettier data={selectedContext.json} />
+                    {selectedContext?.kind === 'advanced' ? (
+                        <Box maxHeight="65vh" minWidth={0} overflow="auto">
+                            {selectedContext.rawSummary && (
+                                <>
+                                    <Typography variant="body2" marginBottom={0.5}>
+                                        <b>Summary</b>
+                                    </Typography>
+                                    <Typography
+                                        variant="body2"
+                                        marginBottom={1.5}
+                                        sx={{ overflowWrap: 'anywhere' }}
+                                    >
+                                        {selectedContext.rawSummary}
+                                    </Typography>
+                                </>
+                            )}
+                            {selectedContext.json.stdOut?.length > 0 && (
+                                <>
+                                    <Typography variant="body2" marginBottom={0.5}>
+                                        <b>Standard output</b>
+                                    </Typography>
+                                    <Box maxHeight="30vh" marginBottom={1.5} minWidth={0} overflow="auto">
+                                        <JsonPrettier data={selectedContext.json.stdOut} />
+                                    </Box>
+                                </>
+                            )}
+                            {selectedContext.json.stdErr?.length > 0 && (
+                                <>
+                                    <Typography variant="body2" marginBottom={0.5}>
+                                        <b>Standard error</b>
+                                    </Typography>
+                                    <Box maxHeight="30vh" marginBottom={1.5} minWidth={0} overflow="auto">
+                                        <JsonPrettier data={selectedContext.json.stdErr} />
+                                    </Box>
+                                </>
+                            )}
+                            {selectedContext.context && (
+                                <>
+                                    <Typography variant="body2" marginBottom={0.5}>
+                                        <b>Process context</b>
+                                    </Typography>
+                                    <Box maxHeight="30vh" marginBottom={1.5} minWidth={0} overflow="auto">
+                                        <JsonPrettier data={selectedContext.context} />
+                                    </Box>
+                                </>
+                            )}
+                            <Typography variant="body2" marginBottom={0.5}>
+                                <b>Complete task JSON</b>
+                            </Typography>
+                            <Box maxHeight="30vh" minWidth={0} overflow="auto">
+                                <JsonPrettier data={selectedContext.json} />
+                            </Box>
                         </Box>
                     ) : (
                         selectedContext && <ReactMarkdown>{selectedContext.description}</ReactMarkdown>

--- a/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
@@ -212,21 +212,34 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
 
     return (
         <Box height="100%" overflow="auto" paddingTop={1}>
-            <ApprovalReviewButton executionUrl={executionUrl} />
             {actionsUnavailable && (
                 <Alert severity="warning" sx={{ marginBottom: 1 }}>
                     Approval actions are temporarily unavailable.
                 </Alert>
             )}
             {!approvals.length ? (
-                <Typography mt={2} align="center" variant="subtitle1">
-                    No approvals are required for this execution
-                </Typography>
+                <>
+                    <Box display="flex" justifyContent="flex-end">
+                        <ApprovalReviewButton executionUrl={executionUrl} />
+                    </Box>
+                    <Typography mt={2} align="center" variant="subtitle1">
+                        No approvals are required for this execution
+                    </Typography>
+                </>
             ) : (
                 <>
-                    <Typography variant="body2" color="text.secondary" marginBottom={1}>
-                        {awaitingCount} awaiting · {blockedCount} blocked · {approvedCount} approved
-                    </Typography>
+                    <Stack
+                        direction="row"
+                        justifyContent="space-between"
+                        alignItems="center"
+                        spacing={1}
+                        marginBottom={1}
+                    >
+                        <Typography variant="body2" color="text.secondary">
+                            {awaitingCount} awaiting · {blockedCount} blocked · {approvedCount} approved
+                        </Typography>
+                        <ApprovalReviewButton executionUrl={executionUrl} />
+                    </Stack>
                     <Stack spacing={1}>
                         {approvals.map((approval) => {
                             const key = taskKey(approval.processId, approval.taskId);

--- a/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
@@ -21,8 +21,6 @@ import { ITask } from '../task/types';
 import { IExecutionPlan, IExecutionTaskJson, TExecutionStatus } from './types';
 import {
     formatApprovalDate,
-    formatApprovalSummary,
-    formatApprovalSummaryParts,
     formatApprovalWait,
     getExecutionApprovals,
 } from './approvalUtils';
@@ -70,7 +68,6 @@ type TApprovalDialog =
     | {
           kind: 'advanced';
           summary: string;
-          rawSummary: string;
           json: IExecutionTaskJson;
           context: null | Record<string, unknown>;
       };
@@ -256,8 +253,6 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
                             const isFocused = focusedApprovalKey === key;
                             const taskDetails = taskJsonByKey.get(key);
                             const taskJson = taskDetails?.task;
-                            const displaySummary = formatApprovalSummary(approval.summary);
-                            const summaryParts = formatApprovalSummaryParts(approval.summary);
 
                             return (
                                 <Box
@@ -278,19 +273,7 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
                                                 title={approval.summary}
                                                 sx={{ overflowWrap: 'anywhere' }}
                                             >
-                                                {summaryParts.prefix}
-                                                {summaryParts.name && (
-                                                    <>
-                                                        {' '}
-                                                        <b>{summaryParts.name}</b>
-                                                    </>
-                                                )}
-                                                {summaryParts.cluster && (
-                                                    <>
-                                                        {' '}
-                                                        in <b>{summaryParts.cluster}</b>
-                                                    </>
-                                                )}
+                                                {approval.summary}
                                             </Typography>
                                             <Typography variant="body2">
                                                 Approval group: <b>{approval.group || 'Unknown'}</b>
@@ -332,7 +315,7 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
                                                 title={approval.blockedBy[0].label}
                                                 sx={{ overflowWrap: 'anywhere' }}
                                             >
-                                                <b>Waiting for:</b> {formatApprovalSummary(approval.blockedBy[0].label)}
+                                                <b>Waiting for:</b> {approval.blockedBy[0].label}
                                             </Typography>
                                             {approval.blockedBy.length > 1 && (
                                                 <Typography variant="caption" color="text.secondary">
@@ -352,7 +335,7 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
                                                         setSelectedContext({
                                                             kind: 'description',
                                                             description: approval.description,
-                                                            summary: displaySummary,
+                                                            summary: approval.summary,
                                                         })
                                                     }
                                                     sx={{ paddingLeft: 0, textTransform: 'none' }}
@@ -369,8 +352,7 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
                                                             kind: 'advanced',
                                                             json: taskJson,
                                                             context: taskDetails?.context ?? null,
-                                                            summary: displaySummary,
-                                                            rawSummary: approval.summary,
+                                                            summary: approval.summary,
                                                         })
                                                     }
                                                     sx={{ paddingLeft: 0, textTransform: 'none' }}
@@ -490,20 +472,6 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
                 >
                     {selectedContext?.kind === 'advanced' ? (
                         <Box maxHeight="65vh" minWidth={0} overflow="auto">
-                            {selectedContext.rawSummary && (
-                                <>
-                                    <Typography variant="body2" marginBottom={0.5}>
-                                        <b>Summary</b>
-                                    </Typography>
-                                    <Typography
-                                        variant="body2"
-                                        marginBottom={1.5}
-                                        sx={{ overflowWrap: 'anywhere' }}
-                                    >
-                                        {selectedContext.rawSummary}
-                                    </Typography>
-                                </>
-                            )}
                             {selectedContext.json.stdOut?.length > 0 && (
                                 <>
                                     <Typography variant="body2" marginBottom={0.5}>

--- a/core/src/main/resources/webapp/src/components/execution/NodeExecutionStatus.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/NodeExecutionStatus.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Box, Typography, Tab } from '@mui/material';
 import { TabContext, TabList, TabPanel } from '@material-ui/lab';
 import { IExecutionPlan, TTaskNode } from './types';
 import JsonPrettier from '../common/JsonPrettier';
 import ExecutionApprovals from './ExecutionApprovals';
+import { GROUP_APPROVAL_TASK_DEFINITION_ID } from './approvalUtils';
 
 interface INodeExecutionStatusProps {
     node: TTaskNode | null;
@@ -13,11 +14,24 @@ interface INodeExecutionStatusProps {
 const NodeExecutionStatus: React.FC<INodeExecutionStatusProps> = ({ node, plan }) => {
     const [selectedTab, setSelectedTab] = useState('approvals');
 
+    const focusedApprovalKey = useMemo(() => {
+        const taskId = node?.data?.taskJson?.label;
+        if (!node || !taskId || node.data?.taskJson?.task?.taskDefinitionId !== GROUP_APPROVAL_TASK_DEFINITION_ID) {
+            return null;
+        }
+        const match = Object.entries(plan ?? {}).find(
+            ([planId, planEntry]) =>
+                Boolean(planEntry.process?.allTasks?.[taskId]) && node.id === `${planId}-${taskId}`
+        );
+        const process = match?.[1].process;
+        return process ? `${process.processId}:${taskId}` : null;
+    }, [node?.id, plan]);
+
     useEffect(() => {
         if (node) {
-            setSelectedTab('task_status');
+            setSelectedTab(focusedApprovalKey ? 'approvals' : 'task_status');
         }
-    }, [node?.id]);
+    }, [node?.id, focusedApprovalKey]);
 
     const data = node?.data;
     return (
@@ -46,7 +60,7 @@ const NodeExecutionStatus: React.FC<INodeExecutionStatusProps> = ({ node, plan }
                         <Tab label="Process Context" value="process_context" disabled={!data} />
                     </TabList>
                     <TabPanel value="approvals" style={{ padding: '0px', height: 'calc(100% - 48px)' }}>
-                        <ExecutionApprovals plan={plan} />
+                        <ExecutionApprovals plan={plan} focusedApprovalKey={focusedApprovalKey} />
                     </TabPanel>
                     <TabPanel value="task_status" style={{ padding: '0px', height: '100%' }}>
                         {data && (

--- a/core/src/main/resources/webapp/src/components/execution/NodeExecutionStatus.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/NodeExecutionStatus.tsx
@@ -1,8 +1,6 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import { Box, Typography, Tab } from '@mui/material';
-import { TabContext, TabList, TabPanel } from '@material-ui/lab';
+import React, { useMemo } from 'react';
+import { Box, Typography } from '@mui/material';
 import { IExecutionPlan, TTaskNode } from './types';
-import JsonPrettier from '../common/JsonPrettier';
 import ExecutionApprovals from './ExecutionApprovals';
 import { GROUP_APPROVAL_TASK_DEFINITION_ID } from './approvalUtils';
 
@@ -12,11 +10,9 @@ interface INodeExecutionStatusProps {
 }
 
 const NodeExecutionStatus: React.FC<INodeExecutionStatusProps> = ({ node, plan }) => {
-    const [selectedTab, setSelectedTab] = useState('approvals');
-
     const focusedApprovalKey = useMemo(() => {
         const taskId = node?.data?.taskJson?.label;
-        if (!node || !taskId || node.data?.taskJson?.task?.taskDefinitionId !== GROUP_APPROVAL_TASK_DEFINITION_ID) {
+        if (!node || !taskId) {
             return null;
         }
         const match = Object.entries(plan ?? {}).find(
@@ -24,80 +20,25 @@ const NodeExecutionStatus: React.FC<INodeExecutionStatusProps> = ({ node, plan }
                 Boolean(planEntry.process?.allTasks?.[taskId]) && node.id === `${planId}-${taskId}`
         );
         const process = match?.[1].process;
-        return process ? `${process.processId}:${taskId}` : null;
+        if (!process) {
+            return null;
+        }
+        if (node.data?.taskJson?.task?.taskDefinitionId === GROUP_APPROVAL_TASK_DEFINITION_ID) {
+            return `${process.processId}:${taskId}`;
+        }
+        const approvalTaskId = Object.entries(process.allTasks ?? {}).find(
+            ([, task]) => task.taskDefinitionId === GROUP_APPROVAL_TASK_DEFINITION_ID
+        )?.[0];
+        return approvalTaskId ? `${process.processId}:${approvalTaskId}` : null;
     }, [node?.id, plan]);
 
-    useEffect(() => {
-        if (node) {
-            setSelectedTab(focusedApprovalKey ? 'approvals' : 'task_status');
-        }
-    }, [node?.id, focusedApprovalKey]);
-
-    const data = node?.data;
     return (
         <Box justifyContent="center" flex="1" height="100%" width="100%">
             <Typography align="center" variant="subtitle1" style={{ background: '#f6f4f4' }}>
-                {data ? (
-                    <>
-                        <b>{data.taskJson?.label}</b>
-                        <span style={{ marginLeft: '2px', fontSize: '14px' }}>
-                            ({data.taskJson?.task?.status})
-                        </span>
-                    </>
-                ) : (
-                    <b>Execution approvals</b>
-                )}
+                <b>Execution approvals</b>
             </Typography>
             <Box justifyContent="center" flex="1" height="100%" width="100%">
-                <TabContext value={selectedTab}>
-                    <TabList
-                        onChange={(_, newVal) => {
-                            setSelectedTab(newVal);
-                        }}
-                    >
-                        <Tab label="Approvals" value="approvals" />
-                        <Tab label="Task Status" value="task_status" disabled={!data} />
-                        <Tab label="Process Context" value="process_context" disabled={!data} />
-                    </TabList>
-                    <TabPanel value="approvals" style={{ padding: '0px', height: 'calc(100% - 48px)' }}>
-                        <ExecutionApprovals plan={plan} focusedApprovalKey={focusedApprovalKey} />
-                    </TabPanel>
-                    <TabPanel value="task_status" style={{ padding: '0px', height: '100%' }}>
-                        {data && (
-                            <>
-                                <Box maxHeight="25%" display="flex" flexDirection="column">
-                                    <Typography style={{ paddingTop: '8px' }}>Standard Output</Typography>
-                                    <JsonPrettier data={data.taskJson?.task?.stdOut} />
-                                </Box>
-                                <Box maxHeight="25%" display="flex" flexDirection="column">
-                                    <Typography style={{ paddingTop: '8px' }}>Error</Typography>
-                                    <JsonPrettier data={data.taskJson?.task?.stdErr} />
-                                </Box>
-                                <Box height="50%" display="flex" flexDirection="column">
-                                    <Typography style={{ paddingTop: '8px' }}>Complete JSON</Typography>
-                                    <JsonPrettier data={data.taskJson} />
-                                </Box>
-                            </>
-                        )}
-                    </TabPanel>
-                    <TabPanel
-                        value="process_context"
-                        style={{
-                            padding: '0px',
-                            paddingTop: '12px',
-                            height: '100%',
-                            overflow: 'scroll',
-                        }}
-                    >
-                        {data?.contextJson ? (
-                            <JsonPrettier data={data.contextJson as Record<string, unknown>} />
-                        ) : (
-                            <Typography mt={2} align="center" variant="subtitle1">
-                                No process context found
-                            </Typography>
-                        )}
-                    </TabPanel>
-                </TabContext>
+                <ExecutionApprovals plan={plan} focusedApprovalKey={focusedApprovalKey} />
             </Box>
         </Box>
     );

--- a/core/src/main/resources/webapp/src/components/execution/PlanGraph.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/PlanGraph.tsx
@@ -6,6 +6,7 @@ import NodeExecutionStatus from './NodeExecutionStatus';
 import TaskNode from './TaskNode';
 import { useStyles } from '../../AppStyles';
 import { buildGraphElementsFromPlan, organizeGraphElements } from '../../const/graphHelper';
+import { GROUP_APPROVAL_TASK_DEFINITION_ID } from './approvalUtils';
 
 interface IPlanGraphProps {
     plan: Record<string, IExecutionPlan>;
@@ -65,6 +66,14 @@ const PlanGraph: React.FC<IPlanGraphProps> = ({ plan, width, height, dagWidth, s
                             maxZoom={4}
                             onNodeClick={(e, node) => {
                                 if (showExecStatus) {
+                                    setSelectedNodeId(node.id);
+                                }
+                            }}
+                            onNodeMouseEnter={(e, node) => {
+                                if (
+                                    showExecStatus &&
+                                    node.data?.taskJson?.task?.taskDefinitionId === GROUP_APPROVAL_TASK_DEFINITION_ID
+                                ) {
                                     setSelectedNodeId(node.id);
                                 }
                             }}

--- a/core/src/main/resources/webapp/src/components/execution/approvalUtils.ts
+++ b/core/src/main/resources/webapp/src/components/execution/approvalUtils.ts
@@ -19,7 +19,36 @@ export interface IExecutionApproval {
     status: TExecutionStatus;
     dependencyLevel: number;
     blockedBy: IExecutionApprovalDependency[];
+    startTimeMs: number;
+    endTimeMs: number;
 }
+
+export const formatApprovalWait = (startTimeMs: number, nowMs: number): string => {
+    if (!startTimeMs || nowMs < startTimeMs) {
+        return '';
+    }
+    const minutes = Math.floor((nowMs - startTimeMs) / 60000);
+    if (minutes < 1) {
+        return 'Waiting for less than a minute';
+    }
+    if (minutes < 60) {
+        return `Waiting for ${minutes} minute${minutes === 1 ? '' : 's'}`;
+    }
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) {
+        return `Waiting for ${hours} hour${hours === 1 ? '' : 's'}`;
+    }
+    const days = Math.floor(hours / 24);
+    return `Waiting for ${days} day${days === 1 ? '' : 's'}`;
+};
+
+export const formatApprovalDate = (endTimeMs: number): string => {
+    if (!endTimeMs) {
+        return '';
+    }
+    const date = new Date(endTimeMs);
+    return `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`;
+};
 
 const readString = (value: unknown): string => (typeof value === 'string' ? value : '');
 
@@ -156,6 +185,8 @@ export const getExecutionApprovals = (plan: Record<string, IExecutionPlan>): IEx
                 status: task.status,
                 dependencyLevel: dependencyLevel(resourceId),
                 blockedBy,
+                startTimeMs: task.startTimeMs || 0,
+                endTimeMs: task.endTimeMs || 0,
             });
         });
     });


### PR DESCRIPTION
## What's changed

### Approval cards (`ExecutionApprovals`)
- Show **"Waiting for N minutes/hours/days"** on awaiting approvals (from the task's start time) and **"Approved M/D/YYYY"** on completed ones, right-aligned under the status chip.
- Make the approval group prominent (bold, directly under the title) and drop the redundant per-card stage line.
- Remove the inline description preview; the description is now available via a **View description** dialog button.
- Add a **View advanced** dialog consolidating everything the old side-panel tabs surfaced: stdout, stderr, process context, and the complete task JSON, each in its own bounded section.
- Button order per card: View description · View advanced · View resource changes.
- Reserve the scrollbar gutter so cards don't shift when the list starts scrolling.

### Graph ↔ approvals interaction (`PlanGraph`, `NodeExecutionStatus`)
- Clicking any node in the execution DAG focuses (highlights + scrolls to) the approval card for that node's process, instead of opening a separate task-status view.
- Hovering an approval task node does the same without a click; hover is limited to approval nodes so sweeping across a large graph doesn't thrash the panel.
- Remove the Task Status and Process Context tabs — their content now lives in the View advanced dialog, so the side panel is just the approvals list.

### Review button (`ApprovalReviewButton`)
- Render inline with the awaiting/blocked/approved counts (counts left, button right) instead of on its own row.
- Support an optional `icon` field from the config endpoint, use the theme secondary color so it stands out from primary-blue actions, and build the `{url}` substitution from the execution id in the plan so the pre-prompt URL is correct even when the execution view is opened from the tasks page dialog.

### JSON rendering (`JsonPrettier`)
- Fix the props signature (positional args meant `height`/`width`/`stringStyle` never applied and `data` was the whole props object).
- Add an opt-in `variant="light"` used by the View advanced dialog: a custom highlighter with an AA-contrast palette on a light background (also handles strings containing escaped quotes, which the previous tokenizer mis-colored). The default dark variant and its existing consumers are unchanged.

### Approval titles
- Approval card titles now render the task summary verbatim. This PR does **not** include shortening/summarizing the titles — more discussion is needed on that implementation.


Base tab with no agent button integration
<img width="1650" height="965" alt="Screenshot 2026-08-11 at 12 25 49 PM" src="https://github.com/user-attachments/assets/09816fa5-7314-488c-99ac-ca02a9e5b551" />

Base tab with agent button integration
<img width="1657" height="965" alt="Screenshot 2026-08-11 at 12 35 38 PM" src="https://github.com/user-attachments/assets/af7b436a-df47-43d5-9de4-3ed7222aeca2" />

View description modal
<img width="1652" height="967" alt="Screenshot 2026-08-11 at 12 25 57 PM" src="https://github.com/user-attachments/assets/3b320743-53a4-426e-bd8f-279a26c0a6c4" />

View advanced modal
<img width="1648" height="965" alt="Screenshot 2026-08-11 at 12 26 10 PM" src="https://github.com/user-attachments/assets/3cac697f-054d-48f9-b846-228670b19e86" />

Stage 1 approved -- note the "Approved {date}"
<img width="1652" height="956" alt="Screenshot 2026-08-11 at 12 26 30 PM" src="https://github.com/user-attachments/assets/3be7e92d-79c9-4656-b112-47c97b4b988d" />


