### PR TITLE
Aggregate approval details by process task

### DIFF
--- a/core/src/main/resources/webapp/src/components/execution/AdvancedTaskExplorer.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/AdvancedTaskExplorer.tsx
@@ -35,6 +35,7 @@ import {
 } from '@mui/icons-material';
 import { IExecutionTaskJson, TExecutionStatus } from './types';
 import JsonPrettier from '../common/JsonPrettier';
+import { formatDuration } from './approvalUtils';
 
 export interface IApprovalTaskDetails {
     taskId: string;
@@ -130,19 +131,6 @@ const hasContent = (value: unknown): boolean => {
         return Object.keys(value).length > 0;
     }
     return true;
-};
-
-const formatDuration = (startTimeMs: number, endTimeMs: number): string | null => {
-    if (!startTimeMs || !endTimeMs || endTimeMs < startTimeMs) {
-        return null;
-    }
-    const seconds = Math.round((endTimeMs - startTimeMs) / 1000);
-    if (seconds < 60) {
-        return `${seconds}s`;
-    }
-    const minutes = Math.floor(seconds / 60);
-    const remainder = seconds % 60;
-    return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`;
 };
 
 interface IAdvancedSectionProps {

--- a/core/src/main/resources/webapp/src/components/execution/AdvancedTaskExplorer.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/AdvancedTaskExplorer.tsx
@@ -1,0 +1,727 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+    Accordion,
+    AccordionDetails,
+    AccordionSummary,
+    Autocomplete,
+    Badge,
+    Box,
+    Button,
+    Chip,
+    Divider,
+    IconButton,
+    InputAdornment,
+    List,
+    ListItemButton,
+    ListItemIcon,
+    ListItemText,
+    Stack,
+    TextField,
+    ToggleButton,
+    Tooltip,
+    Typography,
+    useMediaQuery,
+    useTheme,
+} from '@mui/material';
+import {
+    Autorenew,
+    CancelOutlined,
+    CheckCircleOutline,
+    Clear,
+    ErrorOutline,
+    ExpandMore,
+    RadioButtonUnchecked,
+    Search,
+} from '@mui/icons-material';
+import { IExecutionTaskJson, TExecutionStatus } from './types';
+import JsonPrettier from '../common/JsonPrettier';
+
+export interface IApprovalTaskDetails {
+    taskId: string;
+    task: IExecutionTaskJson;
+    context: unknown;
+}
+
+type TStatusFilter = 'ALL' | TExecutionStatus;
+
+type TChipColor = 'default' | 'error' | 'info' | 'success' | 'warning';
+
+export const taskStatusColor = (status: TExecutionStatus): TChipColor => {
+    switch (status) {
+        case 'SUCCEEDED':
+            return 'success';
+        case 'FAILED':
+            return 'error';
+        case 'RUNNING':
+            return 'info';
+        case 'CANCELLED':
+            return 'warning';
+        default:
+            return 'default';
+    }
+};
+
+const statusTextColor = (status: TExecutionStatus): string => {
+    const color = taskStatusColor(status);
+    return color === 'default' ? 'text.secondary' : `${color}.main`;
+};
+
+const StatusIcon: React.FC<{ status: TExecutionStatus; fontSize?: 'small' | 'inherit' }> = ({
+    status,
+    fontSize = 'small',
+}) => {
+    const color = taskStatusColor(status);
+    switch (status) {
+        case 'FAILED':
+            return <ErrorOutline color="error" fontSize={fontSize} />;
+        case 'CANCELLED':
+            return <CancelOutlined color="warning" fontSize={fontSize} />;
+        case 'RUNNING':
+            return <Autorenew color="info" fontSize={fontSize} />;
+        case 'SUCCEEDED':
+            return <CheckCircleOutline color="success" fontSize={fontSize} />;
+        default:
+            return <RadioButtonUnchecked color={color === 'default' ? 'disabled' : color} fontSize={fontSize} />;
+    }
+};
+
+// Filters shown in the rail, in the order most useful for debugging.
+const FILTER_ORDER: TExecutionStatus[] = ['FAILED', 'CANCELLED', 'RUNNING', 'SUCCEEDED', 'NOT_STARTED'];
+
+const FILTER_LABEL: Record<TExecutionStatus, string> = {
+    FAILED: 'Failed',
+    CANCELLED: 'Cancelled',
+    RUNNING: 'Running',
+    SUCCEEDED: 'Succeeded',
+    NOT_STARTED: 'Not started',
+};
+
+const transitionLabel = (transition: string): string => {
+    switch (transition) {
+        case 'SUCCEEDED':
+            return 'On success';
+        case 'FAILED':
+            return 'On failure';
+        case 'CANCELLED':
+            return 'If cancelled';
+        default:
+            return `On ${transition.replace(/[_-]+/g, ' ').toLowerCase()}`;
+    }
+};
+
+const transitionOrder = (transition: string): number => {
+    const index = ['SUCCEEDED', 'FAILED', 'CANCELLED'].indexOf(transition);
+    return index >= 0 ? index : 3;
+};
+
+const hasStdErr = (task: IExecutionTaskJson): boolean => Boolean(task.stdErr?.length);
+
+const isFailureStatus = (status: TExecutionStatus): boolean =>
+    status === 'FAILED' || status === 'CANCELLED';
+
+const hasContent = (value: unknown): boolean => {
+    if (value === null || value === undefined) {
+        return false;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value).length > 0;
+    }
+    return true;
+};
+
+const formatDuration = (startTimeMs: number, endTimeMs: number): string | null => {
+    if (!startTimeMs || !endTimeMs || endTimeMs < startTimeMs) {
+        return null;
+    }
+    const seconds = Math.round((endTimeMs - startTimeMs) / 1000);
+    if (seconds < 60) {
+        return `${seconds}s`;
+    }
+    const minutes = Math.floor(seconds / 60);
+    const remainder = seconds % 60;
+    return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`;
+};
+
+interface IAdvancedSectionProps {
+    title: string;
+    data?: Object;
+    emptyMessage?: string;
+    defaultExpanded?: boolean;
+    errorMarker?: boolean;
+    meta?: string;
+}
+
+const AdvancedSection: React.FC<IAdvancedSectionProps> = ({
+    title,
+    data,
+    emptyMessage,
+    defaultExpanded = false,
+    errorMarker = false,
+    meta,
+}) => {
+    const isEmpty = data === undefined;
+    return (
+        <Accordion
+            defaultExpanded={defaultExpanded}
+            disableGutters
+            square
+            elevation={0}
+            sx={{
+                borderTop: 1,
+                borderColor: 'divider',
+                '&:before': { display: 'none' },
+            }}
+        >
+            <AccordionSummary
+                expandIcon={<ExpandMore fontSize="small" />}
+                sx={{
+                    minHeight: 0,
+                    px: 0,
+                    '& .MuiAccordionSummary-content': { my: 0.75, alignItems: 'center' },
+                }}
+            >
+                {errorMarker && <ErrorOutline color="error" fontSize="small" sx={{ mr: 0.75 }} />}
+                <Typography variant="body2">{title}</Typography>
+                {meta && (
+                    <Typography variant="caption" color="text.secondary" sx={{ ml: 0.75 }}>
+                        {meta}
+                    </Typography>
+                )}
+            </AccordionSummary>
+            <AccordionDetails sx={{ px: 0, pt: 0, pb: 1, minWidth: 0 }}>
+                {isEmpty ? (
+                    <Typography variant="caption" color="text.secondary">
+                        {emptyMessage}
+                    </Typography>
+                ) : (
+                    <JsonPrettier data={data as Object} variant="light" />
+                )}
+            </AccordionDetails>
+        </Accordion>
+    );
+};
+
+interface IAdvancedTaskDetailsProps {
+    details: IApprovalTaskDetails;
+    onNavigate: (taskId: string) => void;
+    isKnownTask: (taskId: string) => boolean;
+    taskOrder: ReadonlyMap<string, number>;
+}
+
+const AdvancedTaskDetails: React.FC<IAdvancedTaskDetailsProps> = ({
+    details,
+    onNavigate,
+    isKnownTask,
+    taskOrder,
+}) => {
+    const { taskId, task, context } = details;
+    const stdErrPresent = hasStdErr(task);
+    const stdOutPresent = Boolean(task.stdOut?.length);
+    const contextPresent = hasContent(context);
+    const duration = formatDuration(task.startTimeMs, task.endTimeMs);
+    const downstreamGroups = useMemo(() => {
+        return Object.entries(task.nextPointers ?? {})
+            .sort(([left], [right]) => transitionOrder(left) - transitionOrder(right))
+            .map(([transition, taskIds]) => ({
+                transition,
+                taskIds: Array.from(
+                    new Set(taskIds.filter((next) => next && isKnownTask(next)))
+                ).sort(
+                    (left, right) =>
+                        (taskOrder.get(left) ?? Number.MAX_SAFE_INTEGER) -
+                        (taskOrder.get(right) ?? Number.MAX_SAFE_INTEGER)
+                ),
+            }))
+            .filter(({ taskIds }) => taskIds.length > 0);
+    }, [task.nextPointers, isKnownTask, taskOrder]);
+
+    return (
+        <Box>
+            <Stack direction="row" alignItems="baseline" justifyContent="space-between" spacing={1}>
+                <Typography variant="subtitle2" sx={{ overflowWrap: 'anywhere', minWidth: 0 }}>
+                    {taskId}
+                </Typography>
+                <Stack direction="row" alignItems="center" spacing={0.5} sx={{ flexShrink: 0 }}>
+                    <StatusIcon status={task.status} fontSize="inherit" />
+                    <Typography variant="caption" color={statusTextColor(task.status)}>
+                        {task.status}
+                    </Typography>
+                </Stack>
+            </Stack>
+            <Typography
+                variant="caption"
+                color="text.secondary"
+                display="block"
+                sx={{ overflowWrap: 'anywhere' }}
+            >
+                {task.taskDefinitionId}
+                {duration ? ` · ${duration}` : ''}
+            </Typography>
+            {downstreamGroups.length > 0 && (
+                <Stack spacing={0.5} mt={0.75}>
+                    {downstreamGroups.map(({ transition, taskIds }) => (
+                        <Box
+                            key={transition}
+                            display="flex"
+                            flexWrap="wrap"
+                            alignItems="center"
+                            gap={0.5}
+                        >
+                            <Typography
+                                variant="caption"
+                                color="text.secondary"
+                                sx={{ minWidth: 72 }}
+                            >
+                                {transitionLabel(transition)} →
+                            </Typography>
+                            {taskIds.map((next) => (
+                                <Chip
+                                    key={next}
+                                    size="small"
+                                    variant="outlined"
+                                    clickable
+                                    onClick={() => onNavigate(next)}
+                                    label={next}
+                                    sx={{
+                                        height: 20,
+                                        maxWidth: 200,
+                                        '& .MuiChip-label': {
+                                            px: 0.75,
+                                            overflow: 'hidden',
+                                            textOverflow: 'ellipsis',
+                                        },
+                                    }}
+                                />
+                            ))}
+                        </Box>
+                    ))}
+                </Stack>
+            )}
+            <Box mt={1}>
+                <AdvancedSection
+                    title="Standard error"
+                    data={stdErrPresent ? task.stdErr : undefined}
+                    emptyMessage="No standard error"
+                    defaultExpanded={stdErrPresent}
+                    errorMarker={stdErrPresent}
+                    meta={
+                        stdErrPresent
+                            ? `${task.stdErr.length} line${task.stdErr.length > 1 ? 's' : ''}`
+                            : undefined
+                    }
+                />
+                <AdvancedSection
+                    title="Standard output"
+                    data={stdOutPresent ? task.stdOut : undefined}
+                    emptyMessage="No standard output"
+                    defaultExpanded={stdOutPresent}
+                />
+                <AdvancedSection
+                    title="Process context"
+                    data={contextPresent ? (context as Object) : undefined}
+                    emptyMessage="No process context"
+                    defaultExpanded={contextPresent}
+                />
+                <AdvancedSection title="Complete task JSON" data={task} defaultExpanded />
+            </Box>
+        </Box>
+    );
+};
+
+interface ITaskNavItemProps {
+    index: number;
+    details: IApprovalTaskDetails;
+    selected: boolean;
+    onSelect: (taskId: string) => void;
+    registerRef: (taskId: string, node: HTMLDivElement | null) => void;
+    optionId: string;
+}
+
+const TaskNavItem: React.FC<ITaskNavItemProps> = ({
+    index,
+    details,
+    selected,
+    onSelect,
+    registerRef,
+    optionId,
+}) => {
+    const { taskId, task } = details;
+    const stdErrPresent = hasStdErr(task);
+    return (
+        <ListItemButton
+            id={optionId}
+            role="option"
+            aria-selected={selected}
+            selected={selected}
+            tabIndex={-1}
+            ref={(node: HTMLDivElement | null) => registerRef(taskId, node)}
+            onClick={() => onSelect(taskId)}
+            sx={{ alignItems: 'flex-start', gap: 1, py: 0.75 }}
+        >
+            <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ minWidth: 20, textAlign: 'right', mt: 0.25, flexShrink: 0 }}
+            >
+                {index + 1}
+            </Typography>
+            <ListItemIcon sx={{ minWidth: 0, mt: 0.25 }}>
+                <StatusIcon status={task.status} />
+            </ListItemIcon>
+            <ListItemText
+                primary={taskId}
+                secondary={task.taskDefinitionId}
+                primaryTypographyProps={{ noWrap: true, title: taskId }}
+                secondaryTypographyProps={{ noWrap: true, title: task.taskDefinitionId, variant: 'caption' }}
+                sx={{ minWidth: 0, my: 0 }}
+            />
+            {stdErrPresent && (
+                <Tooltip title="Has standard error output" arrow>
+                    <Badge color="error" variant="dot" sx={{ mt: 1, mr: 0.5 }} />
+                </Tooltip>
+            )}
+        </ListItemButton>
+    );
+};
+
+interface IAdvancedTaskExplorerProps {
+    tasks: IApprovalTaskDetails[];
+    initialTaskId: string;
+}
+
+const AdvancedTaskExplorer: React.FC<IAdvancedTaskExplorerProps> = ({ tasks, initialTaskId }) => {
+    const theme = useTheme();
+    const isNarrow = useMediaQuery(theme.breakpoints.down('sm'));
+    const [selectedTaskId, setSelectedTaskId] = useState(initialTaskId);
+    const [query, setQuery] = useState('');
+    const [statusFilter, setStatusFilter] = useState<TStatusFilter>('ALL');
+    const itemRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+
+    const knownTaskIds = useMemo(() => new Set(tasks.map(({ taskId }) => taskId)), [tasks]);
+    const isKnownTask = useCallback((taskId: string) => knownTaskIds.has(taskId), [knownTaskIds]);
+    const taskOrder = useMemo(
+        () => new Map(tasks.map(({ taskId }, index) => [taskId, index])),
+        [tasks]
+    );
+
+    const counts = useMemo(() => {
+        const byStatus = new Map<TExecutionStatus, number>();
+        tasks.forEach(({ task }) => {
+            byStatus.set(task.status, (byStatus.get(task.status) ?? 0) + 1);
+        });
+        return byStatus;
+    }, [tasks]);
+
+    const issueTasks = useMemo(
+        () => tasks.filter(({ task }) => isFailureStatus(task.status) || hasStdErr(task)),
+        [tasks]
+    );
+    const failureCount = issueTasks.length;
+
+    const visibleTasks = useMemo(() => {
+        const normalizedQuery = query.trim().toLowerCase();
+        return tasks.filter(({ taskId, task }) => {
+            if (statusFilter !== 'ALL' && task.status !== statusFilter) {
+                return false;
+            }
+            if (!normalizedQuery) {
+                return true;
+            }
+            return (
+                taskId.toLowerCase().includes(normalizedQuery) ||
+                task.taskDefinitionId.toLowerCase().includes(normalizedQuery)
+            );
+        });
+    }, [tasks, query, statusFilter]);
+
+    // Selection is derived from the full task set so filtering never blanks the detail pane.
+    const selectedDetails = useMemo(
+        () => tasks.find(({ taskId }) => taskId === selectedTaskId) ?? tasks[0],
+        [tasks, selectedTaskId]
+    );
+
+    const optionId = useCallback((taskId: string) => `advanced-task-option-${taskId}`, []);
+
+    const registerRef = useCallback((taskId: string, node: HTMLDivElement | null) => {
+        if (node) {
+            itemRefs.current.set(taskId, node);
+        } else {
+            itemRefs.current.delete(taskId);
+        }
+    }, []);
+
+    useEffect(() => {
+        const node = selectedDetails ? itemRefs.current.get(selectedDetails.taskId) : undefined;
+        node?.scrollIntoView({ block: 'nearest' });
+    }, [selectedDetails]);
+
+    const selectedIssueIndex = issueTasks.findIndex(({ taskId }) => taskId === selectedTaskId);
+    const nextIssueIndex = issueTasks.length ? (selectedIssueIndex + 1) % issueTasks.length : -1;
+    const nextIssueLabel =
+        nextIssueIndex >= 0 ? `Next issue (${nextIssueIndex + 1} of ${issueTasks.length})` : '';
+
+    const jumpToNextIssue = useCallback(() => {
+        const nextIssue = issueTasks[nextIssueIndex];
+        if (nextIssue) {
+            setStatusFilter('ALL');
+            setQuery('');
+            setSelectedTaskId(nextIssue.taskId);
+        }
+    }, [issueTasks, nextIssueIndex]);
+
+    const handleListKeyDown = useCallback(
+        (event: React.KeyboardEvent<HTMLUListElement>) => {
+            if (!visibleTasks.length) {
+                return;
+            }
+            const currentIndex = visibleTasks.findIndex(({ taskId }) => taskId === selectedDetails?.taskId);
+            let nextIndex: number | null = null;
+            switch (event.key) {
+                case 'ArrowDown':
+                    nextIndex = currentIndex < 0 ? 0 : Math.min(currentIndex + 1, visibleTasks.length - 1);
+                    break;
+                case 'ArrowUp':
+                    nextIndex = currentIndex <= 0 ? 0 : currentIndex - 1;
+                    break;
+                case 'Home':
+                    nextIndex = 0;
+                    break;
+                case 'End':
+                    nextIndex = visibleTasks.length - 1;
+                    break;
+                default:
+                    return;
+            }
+            if (nextIndex !== null) {
+                event.preventDefault();
+                setSelectedTaskId(visibleTasks[nextIndex].taskId);
+            }
+        },
+        [visibleTasks, selectedDetails]
+    );
+
+    const searchField = (
+        <TextField
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            size="small"
+            fullWidth
+            placeholder="Filter tasks…"
+            aria-label="Filter tasks by id or definition"
+            InputProps={{
+                startAdornment: (
+                    <InputAdornment position="start">
+                        <Search fontSize="small" />
+                    </InputAdornment>
+                ),
+                endAdornment: query ? (
+                    <InputAdornment position="end">
+                        <IconButton size="small" aria-label="Clear filter" onClick={() => setQuery('')}>
+                            <Clear fontSize="small" />
+                        </IconButton>
+                    </InputAdornment>
+                ) : undefined,
+            }}
+        />
+    );
+
+    const filters: Array<{ value: TStatusFilter; label: string; count: number }> = [
+        { value: 'ALL', label: 'All', count: tasks.length },
+        ...FILTER_ORDER.filter((status) => (counts.get(status) ?? 0) > 0).map((status) => ({
+            value: status,
+            label: FILTER_LABEL[status],
+            count: counts.get(status) ?? 0,
+        })),
+    ];
+    const filterToggles = (
+        <Box
+            role="group"
+            aria-label="Filter tasks by status"
+            display="grid"
+            gridTemplateColumns="repeat(auto-fit, minmax(104px, 1fr))"
+            gap={0.5}
+            width="100%"
+        >
+            {filters.map(({ value, label, count }) => (
+                <ToggleButton
+                    key={value}
+                    value={value}
+                    selected={statusFilter === value}
+                    size="small"
+                    onClick={() => setStatusFilter(value)}
+                    sx={{
+                        border: 1,
+                        borderColor: 'divider',
+                        borderRadius: '4px !important',
+                        minWidth: 0,
+                        px: 1,
+                        py: 0.375,
+                        textTransform: 'none',
+                        whiteSpace: 'nowrap',
+                        width: '100%',
+                    }}
+                >
+                    <Box
+                        display="flex"
+                        alignItems="center"
+                        justifyContent="space-between"
+                        gap={0.75}
+                        width="100%"
+                        minWidth={0}
+                    >
+                        <Typography variant="caption" noWrap>
+                            {label}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                            {count}
+                        </Typography>
+                    </Box>
+                </ToggleButton>
+            ))}
+        </Box>
+    );
+
+    const detailPane = (
+        <Box
+            flex={1}
+            minWidth={0}
+            maxHeight={isNarrow ? undefined : '65vh'}
+            overflow="auto"
+            padding={1.5}
+        >
+            {selectedDetails ? (
+                <AdvancedTaskDetails
+                    key={selectedDetails.taskId}
+                    details={selectedDetails}
+                    onNavigate={setSelectedTaskId}
+                    isKnownTask={isKnownTask}
+                    taskOrder={taskOrder}
+                />
+            ) : (
+                <Typography variant="body2" color="text.secondary">
+                    No task details found
+                </Typography>
+            )}
+        </Box>
+    );
+
+    if (isNarrow) {
+        return (
+            <Box padding={2}>
+                <Stack spacing={1.5}>
+                    <Autocomplete
+                        options={tasks}
+                        value={selectedDetails ?? null}
+                        onChange={(_, value) => value && setSelectedTaskId(value.taskId)}
+                        getOptionLabel={(option) => option.taskId}
+                        isOptionEqualToValue={(a, b) => a.taskId === b.taskId}
+                        disableClearable
+                        renderOption={(props, option) => (
+                            <li {...props} key={option.taskId}>
+                                <Stack direction="row" alignItems="center" spacing={1} minWidth={0}>
+                                    <StatusIcon status={option.task.status} />
+                                    <Box minWidth={0}>
+                                        <Typography variant="body2" noWrap>
+                                            {option.taskId}
+                                        </Typography>
+                                        <Typography variant="caption" color="text.secondary" noWrap display="block">
+                                            {option.task.taskDefinitionId}
+                                        </Typography>
+                                    </Box>
+                                </Stack>
+                            </li>
+                        )}
+                        renderInput={(params) => (
+                            <TextField {...params} size="small" label="Select task" placeholder="Search tasks…" />
+                        )}
+                    />
+                    {failureCount > 0 && (
+                        <Button size="small" color="error" onClick={jumpToNextIssue} sx={{ alignSelf: 'flex-start', textTransform: 'none' }}>
+                            {nextIssueLabel}
+                        </Button>
+                    )}
+                </Stack>
+                {detailPane}
+            </Box>
+        );
+    }
+
+    return (
+        <Box display="flex" minWidth={0} width="100%" alignItems="stretch">
+            <Box
+                width="clamp(264px, 31%, 360px)"
+                minWidth={264}
+                flexShrink={1}
+                borderRight={1}
+                borderColor="divider"
+                display="flex"
+                flexDirection="column"
+                maxHeight="65vh"
+            >
+                <Box padding={1.5} borderBottom={1} borderColor="divider">
+                    <Stack spacing={1}>
+                        {searchField}
+                        {filterToggles}
+                        <Box
+                            display="flex"
+                            flexWrap="wrap"
+                            justifyContent="space-between"
+                            alignItems="center"
+                            columnGap={1}
+                            rowGap={0.5}
+                        >
+                            <Typography variant="caption" color="text.secondary">
+                                {visibleTasks.length} of {tasks.length} shown
+                            </Typography>
+                            {failureCount > 0 && (
+                                <Button
+                                    size="small"
+                                    color="error"
+                                    onClick={jumpToNextIssue}
+                                    sx={{ textTransform: 'none', py: 0, minWidth: 0 }}
+                                >
+                                    {nextIssueLabel}
+                                </Button>
+                            )}
+                        </Box>
+                    </Stack>
+                </Box>
+                <List
+                    role="listbox"
+                    aria-label="Execution tasks"
+                    aria-activedescendant={selectedDetails ? optionId(selectedDetails.taskId) : undefined}
+                    tabIndex={0}
+                    onKeyDown={handleListKeyDown}
+                    sx={{ overflow: 'auto', flex: 1, py: 0 }}
+                >
+                    {visibleTasks.length ? (
+                        visibleTasks.map((details) => (
+                            <TaskNavItem
+                                key={details.taskId}
+                                index={tasks.indexOf(details)}
+                                details={details}
+                                selected={selectedDetails?.taskId === details.taskId}
+                                onSelect={setSelectedTaskId}
+                                registerRef={registerRef}
+                                optionId={optionId(details.taskId)}
+                            />
+                        ))
+                    ) : (
+                        <Box padding={2}>
+                            <Typography variant="body2" color="text.secondary">
+                                No tasks match the current filter.
+                            </Typography>
+                        </Box>
+                    )}
+                </List>
+            </Box>
+            <Divider orientation="vertical" flexItem />
+            {detailPane}
+        </Box>
+    );
+};
+
+export default AdvancedTaskExplorer;

--- a/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
@@ -26,13 +26,14 @@ import {
 } from './approvalUtils';
 import { ResourceJsonDiff } from './ExecPlanJsonDiff';
 import ApprovalReviewButton from './ApprovalReviewButton';
-import JsonPrettier from '../common/JsonPrettier';
+import AdvancedTaskExplorer, { IApprovalTaskDetails } from './AdvancedTaskExplorer';
 
 const TASK_REFRESH_FREQUENCY = 5000;
 
 interface IExecutionApprovalsProps {
     plan: Record<string, IExecutionPlan>;
     focusedApprovalKey?: string | null;
+    focusedTaskKey?: string | null;
 }
 
 const taskKey = (processId: string, taskId: string): string => `${processId}:${taskId}`;
@@ -58,44 +59,56 @@ const statusDisplay = (
     }
 };
 
-interface IApprovalTaskDetails {
-    taskId: string;
-    task: IExecutionTaskJson;
-    context: null | Record<string, unknown>;
-}
-
 type TApprovalDialog =
     | { kind: 'description'; summary: string; description: string }
     | {
           kind: 'advanced';
           summary: string;
-          json: IExecutionTaskJson;
-          context: null | Record<string, unknown>;
-          taskErrors: IApprovalTaskDetails[];
+          tasks: IApprovalTaskDetails[];
+          initialTaskId: string;
       };
 
-const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedApprovalKey }) => {
+const orderedTaskIds = (
+    allTasks: Record<string, IExecutionTaskJson>,
+    startTaskId: string
+): string[] => {
+    const ordered: string[] = [];
+    const visited = new Set<string>();
+    const queue = startTaskId && allTasks[startTaskId] ? [startTaskId] : [];
+
+    while (queue.length) {
+        const taskId = queue.shift();
+        if (!taskId || visited.has(taskId) || !allTasks[taskId]) {
+            continue;
+        }
+        visited.add(taskId);
+        ordered.push(taskId);
+        Object.values(allTasks[taskId].nextPointers ?? {})
+            .flat()
+            .forEach((nextTaskId) => {
+                if (!visited.has(nextTaskId)) {
+                    queue.push(nextTaskId);
+                }
+            });
+    }
+
+    Object.keys(allTasks).forEach((taskId) => {
+        if (!visited.has(taskId)) {
+            ordered.push(taskId);
+        }
+    });
+    return ordered;
+};
+
+const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({
+    plan,
+    focusedApprovalKey,
+    focusedTaskKey,
+}) => {
     const { showSnackbar } = useSnackBar();
     const theme = useTheme();
     const approvals = useMemo(() => getExecutionApprovals(plan), [plan]);
-    const taskJsonByKey = useMemo(() => {
-        const byKey = new Map<string, IApprovalTaskDetails>();
-        Object.values(plan).forEach((planEntry) => {
-            const process = planEntry.process;
-            if (!process) {
-                return;
-            }
-            Object.entries(process.allTasks).forEach(([taskId, task]) => {
-                byKey.set(taskKey(process.processId, taskId), {
-                    taskId,
-                    task,
-                    context: process.processContext?.[taskId] ?? null,
-                });
-            });
-        });
-        return byKey;
-    }, [plan]);
-    const taskErrorsByProcessId = useMemo(() => {
+    const taskDetailsByProcessId = useMemo(() => {
         const byProcessId = new Map<string, IApprovalTaskDetails[]>();
         Object.values(plan).forEach((planEntry) => {
             const process = planEntry.process;
@@ -104,13 +117,11 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
             }
             byProcessId.set(
                 process.processId,
-                Object.entries(process.allTasks)
-                    .filter(([, task]) => task.stdErr?.length > 0)
-                    .map(([taskId, task]) => ({
-                        taskId,
-                        task,
-                        context: process.processContext?.[taskId] ?? null,
-                    }))
+                orderedTaskIds(process.allTasks, process.startTaskId).map((taskId) => ({
+                    taskId,
+                    task: process.allTasks[taskId],
+                    context: process.processContext?.[taskId] ?? null,
+                }))
             );
         });
         return byProcessId;
@@ -280,8 +291,15 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
                             const approvedDate =
                                 approval.status === 'SUCCEEDED' ? formatApprovalDate(approval.endTimeMs) : '';
                             const isFocused = focusedApprovalKey === key;
-                            const taskDetails = taskJsonByKey.get(key);
-                            const taskJson = taskDetails?.task;
+                            const processTasks = taskDetailsByProcessId.get(approval.processId) ?? [];
+                            const focusedTaskId =
+                                isFocused && focusedTaskKey?.startsWith(`${approval.processId}:`)
+                                    ? focusedTaskKey.slice(approval.processId.length + 1)
+                                    : null;
+                            const initialTaskId =
+                                focusedTaskId && processTasks.some(({ taskId }) => taskId === focusedTaskId)
+                                    ? focusedTaskId
+                                    : approval.taskId;
 
                             return (
                                 <Box
@@ -354,7 +372,7 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
                                             )}
                                         </Box>
                                     )}
-                                    {(approval.description || taskJson || resourcePlan) && (
+                                    {(approval.description || processTasks.length || resourcePlan) && (
                                         <Box display="flex" flexWrap="wrap" alignItems="center" gap={1} mt={0.5}>
                                             {approval.description && (
                                                 <Button
@@ -372,17 +390,15 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
                                                     View description
                                                 </Button>
                                             )}
-                                            {taskJson && (
+                                            {processTasks.length > 0 && (
                                                 <Button
                                                     size="small"
                                                     variant="text"
                                                     onClick={() =>
                                                         setSelectedContext({
                                                             kind: 'advanced',
-                                                            json: taskJson,
-                                                            context: taskDetails?.context ?? null,
-                                                            taskErrors:
-                                                                taskErrorsByProcessId.get(approval.processId) ?? [],
+                                                            tasks: processTasks,
+                                                            initialTaskId,
                                                             summary: approval.summary,
                                                         })
                                                     }
@@ -476,7 +492,7 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
                 open={selectedContext !== null}
                 onClose={() => setSelectedContext(null)}
                 fullWidth
-                maxWidth="md"
+                maxWidth="lg"
             >
                 <DialogTitle>
                     {selectedContext?.kind === 'advanced' ? 'Approval details' : 'Approval description'}
@@ -489,6 +505,7 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
                 <DialogContent
                     dividers
                     sx={{
+                        padding: selectedContext?.kind === 'advanced' ? 0 : undefined,
                         '& p, & li, & a': {
                             overflowWrap: 'anywhere',
                             wordBreak: 'break-word',
@@ -502,44 +519,11 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({ plan, focusedA
                     }}
                 >
                     {selectedContext?.kind === 'advanced' ? (
-                        <Box maxHeight="65vh" minWidth={0} overflow="auto">
-                            {selectedContext.json.stdOut?.length > 0 && (
-                                <>
-                                    <Typography variant="body2" marginBottom={0.5}>
-                                        <b>Standard output</b>
-                                    </Typography>
-                                    <Box marginBottom={1.5} minWidth={0}>
-                                        <JsonPrettier data={selectedContext.json.stdOut} variant="light" />
-                                    </Box>
-                                </>
-                            )}
-                            {selectedContext.taskErrors.map(({ taskId, task }) => (
-                                <React.Fragment key={taskId}>
-                                    <Typography variant="body2" marginBottom={0.5}>
-                                        <b>Standard error — {taskId}</b> ({task.status})
-                                    </Typography>
-                                    <Box marginBottom={1.5} minWidth={0}>
-                                        <JsonPrettier data={task.stdErr} variant="light" />
-                                    </Box>
-                                </React.Fragment>
-                            ))}
-                            {selectedContext.context && (
-                                <>
-                                    <Typography variant="body2" marginBottom={0.5}>
-                                        <b>Process context</b>
-                                    </Typography>
-                                    <Box marginBottom={1.5} minWidth={0}>
-                                        <JsonPrettier data={selectedContext.context} variant="light" />
-                                    </Box>
-                                </>
-                            )}
-                            <Typography variant="body2" marginBottom={0.5}>
-                                <b>Complete task JSON</b>
-                            </Typography>
-                            <Box minWidth={0}>
-                                <JsonPrettier data={selectedContext.json} variant="light" />
-                            </Box>
-                        </Box>
+                        <AdvancedTaskExplorer
+                            key={`${selectedContext.summary}:${selectedContext.initialTaskId}`}
+                            tasks={selectedContext.tasks}
+                            initialTaskId={selectedContext.initialTaskId}
+                        />
                     ) : (
                         selectedContext && <ReactMarkdown>{selectedContext.description}</ReactMarkdown>
                     )}

--- a/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
@@ -20,7 +20,7 @@ import { useSnackBar } from '../../context/SnackbarContext';
 import { ITask } from '../task/types';
 import { IExecutionPlan, IExecutionTaskJson, TExecutionStatus } from './types';
 import {
-    formatApprovalDate,
+    formatApprovalTimestamp,
     formatApprovalWait,
     getExecutionApprovals,
 } from './approvalUtils';
@@ -288,8 +288,10 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({
                             const changesExpanded = expandedChanges.has(key);
                             const isAwaiting = approval.status === 'RUNNING' && !isBlocked;
                             const waitingLabel = isAwaiting ? formatApprovalWait(approval.startTimeMs, Date.now()) : '';
-                            const approvedDate =
-                                approval.status === 'SUCCEEDED' ? formatApprovalDate(approval.endTimeMs) : '';
+                            const approvedTimestamp =
+                                approval.status === 'SUCCEEDED'
+                                    ? formatApprovalTimestamp(approval.endTimeMs)
+                                    : '';
                             const isFocused = focusedApprovalKey === key;
                             const processTasks = taskDetailsByProcessId.get(approval.processId) ?? [];
                             const focusedTaskId =
@@ -337,13 +339,13 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({
                                                     {waitingLabel}
                                                 </Typography>
                                             ) : (
-                                                approvedDate && (
+                                                approvedTimestamp && (
                                                     <Typography
                                                         variant="caption"
                                                         color="text.secondary"
                                                         textAlign="right"
                                                     >
-                                                        Approved {approvedDate}
+                                                        Approved {approvedTimestamp}
                                                     </Typography>
                                                 )
                                             )}

--- a/core/src/main/resources/webapp/src/components/execution/NodeExecutionStatus.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/NodeExecutionStatus.tsx
@@ -10,10 +10,10 @@ interface INodeExecutionStatusProps {
 }
 
 const NodeExecutionStatus: React.FC<INodeExecutionStatusProps> = ({ node, plan }) => {
-    const focusedApprovalKey = useMemo(() => {
+    const { focusedApprovalKey, focusedTaskKey } = useMemo(() => {
         const taskId = node?.data?.taskJson?.label;
         if (!node || !taskId) {
-            return null;
+            return { focusedApprovalKey: null, focusedTaskKey: null };
         }
         const match = Object.entries(plan ?? {}).find(
             ([planId, planEntry]) =>
@@ -21,15 +21,22 @@ const NodeExecutionStatus: React.FC<INodeExecutionStatusProps> = ({ node, plan }
         );
         const process = match?.[1].process;
         if (!process) {
-            return null;
+            return { focusedApprovalKey: null, focusedTaskKey: null };
         }
+        const selectedTaskKey = `${process.processId}:${taskId}`;
         if (node.data?.taskJson?.task?.taskDefinitionId === GROUP_APPROVAL_TASK_DEFINITION_ID) {
-            return `${process.processId}:${taskId}`;
+            return {
+                focusedApprovalKey: selectedTaskKey,
+                focusedTaskKey: selectedTaskKey,
+            };
         }
         const approvalTaskId = Object.entries(process.allTasks ?? {}).find(
             ([, task]) => task.taskDefinitionId === GROUP_APPROVAL_TASK_DEFINITION_ID
         )?.[0];
-        return approvalTaskId ? `${process.processId}:${approvalTaskId}` : null;
+        return {
+            focusedApprovalKey: approvalTaskId ? `${process.processId}:${approvalTaskId}` : null,
+            focusedTaskKey: selectedTaskKey,
+        };
     }, [node?.id, plan]);
 
     return (
@@ -38,7 +45,11 @@ const NodeExecutionStatus: React.FC<INodeExecutionStatusProps> = ({ node, plan }
                 <b>Execution approvals</b>
             </Typography>
             <Box justifyContent="center" flex="1" height="100%" width="100%">
-                <ExecutionApprovals plan={plan} focusedApprovalKey={focusedApprovalKey} />
+                <ExecutionApprovals
+                    plan={plan}
+                    focusedApprovalKey={focusedApprovalKey}
+                    focusedTaskKey={focusedTaskKey}
+                />
             </Box>
         </Box>
     );

--- a/core/src/main/resources/webapp/src/components/execution/approvalUtils.ts
+++ b/core/src/main/resources/webapp/src/components/execution/approvalUtils.ts
@@ -50,6 +50,32 @@ export const formatApprovalDate = (endTimeMs: number): string => {
     return `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`;
 };
 
+export const formatApprovalTimestamp = (endTimeMs: number): string => {
+    if (!endTimeMs) {
+        return '';
+    }
+    return new Date(endTimeMs).toLocaleString(undefined, {
+        year: 'numeric',
+        month: 'numeric',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+    });
+};
+
+export const formatDuration = (startTimeMs: number, endTimeMs: number): string | null => {
+    if (!startTimeMs || !endTimeMs || endTimeMs < startTimeMs) {
+        return null;
+    }
+    const seconds = Math.round((endTimeMs - startTimeMs) / 1000);
+    if (seconds < 60) {
+        return `${seconds}s`;
+    }
+    const minutes = Math.floor(seconds / 60);
+    const remainder = seconds % 60;
+    return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`;
+};
+
 const readString = (value: unknown): string => (typeof value === 'string' ? value : '');
 
 const readRecord = (value: unknown): Record<string, unknown> =>


### PR DESCRIPTION
## Summary

- Aggregate every process task correlated with an approval into the View advanced dialog.
- Add a searchable, status-filterable task sidebar ordered by DAG traversal.
- Preserve each task’s standard output, standard error, process context, status, duration, and complete JSON.
- Group downstream navigation by success, failure, and cancellation transitions.
- Cycle through failed, cancelled, and stderr-bearing tasks using Next issue.
- Preselect the corresponding task when navigating from a DAG node.
- Display both the approval date and local approval time.

Note the approved timestamp 
<img width="1455" height="947" alt="Screenshot 2026-08-14 at 12 33 22 PM" src="https://github.com/user-attachments/assets/6e28a72f-7c42-494c-84c2-6f3543fe5669" />

View advanced modal for the singer DAG
<img width="1459" height="946" alt="Screenshot 2026-08-14 at 12 33 35 PM" src="https://github.com/user-attachments/assets/e589391d-6eb0-4f4f-a943-0a2e373e3942" />

## Test plan

- Run the TypeScript check.
- Verify task filtering, issue cycling, transition navigation, and per-task details.
- Verify approval completion timestamps include both date and time.

Made with [Cursor](https://cursor.com)