### PR TITLE
Handle the API response properly

### DIFF
--- a/core/src/main/resources/webapp/src/components/metrics/StatsboardChart.js
+++ b/core/src/main/resources/webapp/src/components/metrics/StatsboardChart.js
@@ -48,15 +48,20 @@ export default class StatsboardChart extends React.Component {
   }
 
   formatResponse(response) {
+    var seriesList = [];
+    if (Array.isArray(response)) {
+      seriesList = response;
+    } else if (response && Array.isArray(response.data)) {
+      seriesList = response.data;
+    }
     var seriesSet = new Set();
     var tempDatapointsObj = {};
-    for (var responseGroup of response) {
-      var datapointsForGroup = responseGroup.datapoints;
+    for (var responseGroup of seriesList) {
+      var datapointsForGroup = responseGroup.datapoints || [];
       if (datapointsForGroup.length === 0) {
         continue;
       }
-      var tags = Object.values(responseGroup['tags']);
-      var metric = responseGroup.metric;
+      var tags = Object.values(responseGroup.tags || {});
       var seriesName = 'y';
       if (tags.length > 0) {
         seriesName = tags[0];


### PR DESCRIPTION
## Summary

### Problem (Why)

The metrics chart assumed the API returned a top-level array of series. When the response is an object envelope (`{data: [...]}`), iterating it throws and the Metrics tab goes blank.

### Solution (What + How)

Handle the API response properly: treat a top-level array as the series list, otherwise use `response.data`. Default missing `datapoints` and `tags` so empty series do not throw.

## Test Plan

- Open a resource Metrics tab against an API that returns `{data: [...]}` — the chart should render instead of a white screen.
- Confirm a top-level array response still charts as before.
