### PR TITLE
Guard null processId when focusing an approval card

### DIFF
--- a/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
+++ b/core/src/main/resources/webapp/src/components/execution/ExecutionApprovals.tsx
@@ -295,7 +295,9 @@ const ExecutionApprovals: React.FC<IExecutionApprovalsProps> = ({
                             const isFocused = focusedApprovalKey === key;
                             const processTasks = taskDetailsByProcessId.get(approval.processId) ?? [];
                             const focusedTaskId =
-                                isFocused && focusedTaskKey?.startsWith(`${approval.processId}:`)
+                                isFocused &&
+                                approval.processId &&
+                                focusedTaskKey?.startsWith(`${approval.processId}:`)
                                     ? focusedTaskKey.slice(approval.processId.length + 1)
                                     : null;
                             const initialTaskId =


### PR DESCRIPTION
## Summary

### Problem (Why)

Hovering or clicking a DAG node for a process that has not started yet blanks the execution page. Those processes have `processId: null`, and the approvals panel read `.length` on that null while resolving the focused task.

### Solution (What + How)

Skip the focused-task slice unless `processId` is present. The card can still render; it falls back to the approval task id.

## Test Plan

- Open an execution whose plan includes a not-started process (`processId` is null).
- Hover or click that process's approval node on the left DAG.
- The approvals list should stay up instead of a white screen.
- Hover a started process's approval node; focus behavior should be unchanged.
